### PR TITLE
Add support for multiple alarm types in describeAlarmHistory

### DIFF
--- a/scripts/go/go-report-alarms/src/libs/CloudWatchService.ts
+++ b/scripts/go/go-report-alarms/src/libs/CloudWatchService.ts
@@ -45,6 +45,7 @@ export class CloudWatchService {
 
     const input: DescribeAlarmHistoryCommandInput = {
       AlarmName: alarmName,
+      AlarmTypes: ['CompositeAlarm', 'MetricAlarm'],
       HistoryItemType: 'Action',
       StartDate: start,
       EndDate: end,


### PR DESCRIPTION
## Description

Enhance the `CloudWatchService` to support multiple alarm types when describing alarm history, allowing for more flexible alarm management.
