### PR TITLE
fix(go-common): use /tmp as base dir in AWS-managed environments

### DIFF
--- a/packages/go-common/src/libs/core/utils/GOPaths.ts
+++ b/packages/go-common/src/libs/core/utils/GOPaths.ts
@@ -441,7 +441,8 @@ export class GOPaths {
    * 1. Constructor option (baseDir)
    * 2. GO_BASE_DIR environment variable
    * 3. Monorepo root (if monorepo mode)
-   * 4. Current working directory
+   * 4. /tmp in AWS-managed environments (Lambda, ECS, etc. where cwd is read-only)
+   * 5. Current working directory
    */
   private resolveBaseDir(): string {
     // Priority 1: Constructor option
@@ -460,7 +461,12 @@ export class GOPaths {
       return this.environmentInfo.monorepoRoot;
     }
 
-    // Priority 4: Current working directory
+    // Priority 4: AWS-managed environments have read-only filesystems except /tmp
+    if (this.environmentInfo.isAWSManaged) {
+      return '/tmp';
+    }
+
+    // Priority 5: Current working directory
     return process.cwd();
   }
 

--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -1,5 +1,5 @@
 {
-  "Parameters" : {
+  "Parameters": {
     "AthenaDatabase": "cdc_analytics_database",
     "AthenaCatalog": "AwsDataCatalog",
     "AthenaWorkgroup": "primary",


### PR DESCRIPTION
  Lambda and other AWS-managed environments have a read-only filesystem
  except for /tmp. GOPaths.resolveBaseDir() now automatically detects
  AWS-managed environments and defaults to /tmp, avoiding ENOENT errors
  when ensureDirectoriesExist() creates data directories