### PR TITLE
fix(lambda): make aws.profile optional for AWS-managed environments

### DIFF
--- a/scripts/send/send-monitor-tpp-messages/src/config.ts
+++ b/scripts/send/send-monitor-tpp-messages/src/config.ts
@@ -40,8 +40,8 @@ export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
   {
     name: 'aws.profile',
     type: Core.GOConfigParameterType.STRING,
-    description: 'AWS SSO profile name (e.g., sso_pn-core-prod)',
-    required: true,
+    description: 'AWS SSO profile name (e.g., sso_pn-core-prod). Not required in AWS-managed environments.',
+    required: false,
     aliases: ['ap'],
   },
   {

--- a/scripts/send/send-monitor-tpp-messages/src/main.ts
+++ b/scripts/send/send-monitor-tpp-messages/src/main.ts
@@ -182,7 +182,7 @@ export async function main(script: Core.GOScript): Promise<void> {
   // Initialize Athena service
   script.logger.section('Initializing AWS Athena');
   const athenaService = new AwsAthenaService({
-    ssoProfile: config.awsProfile,
+    ssoProfile: config.awsProfile ?? null,
     region: config.awsRegion,
   });
 

--- a/scripts/send/send-monitor-tpp-messages/src/types/TPPMonitorConfig.ts
+++ b/scripts/send/send-monitor-tpp-messages/src/types/TPPMonitorConfig.ts
@@ -9,8 +9,8 @@ export interface TPPMonitorConfig {
   /** End date for the query range */
   readonly to: string;
 
-  /** AWS SSO profile name */
-  readonly awsProfile: string;
+  /** AWS SSO profile name (optional in AWS-managed environments) */
+  readonly awsProfile?: string;
 
   /** AWS region (default: eu-south-1) */
   readonly awsRegion: string;


### PR DESCRIPTION
Lambda uses IAM role credentials via the default credential chain, so the SSO profile parameter is not needed. AwsAthenaService already falls back to default credentials when ssoProfile is null.