### PR TITLE
fix(lambda): resolve reports folder via GOPaths for writable path

### DIFF
--- a/functions/go-SendMonitorTppMessagesLambda/src/handler.ts
+++ b/functions/go-SendMonitorTppMessagesLambda/src/handler.ts
@@ -67,7 +67,7 @@ export const handler = script.createLambdaHandler<ScheduledEvent>(async (_event)
   const reportsBucket = process.env['REPORTS_S3_BUCKET'];
   if (reportsBucket) {
     const prefix = process.env['REPORTS_S3_PREFIX'] ?? 'reports/tpp-monitor';
-    const reportsDir = '/tmp/reports';
+    const reportsDir = script.paths.resolvePath('reports', Core.GOPathType.OUTPUT) ?? '/tmp/reports';
 
     const uploader = new S3Uploader(reportsBucket);
     const uploaded = await uploader.uploadDirectory(reportsDir, prefix);

--- a/scripts/send/send-monitor-tpp-messages/src/main.ts
+++ b/scripts/send/send-monitor-tpp-messages/src/main.ts
@@ -188,8 +188,9 @@ export async function main(script: Core.GOScript): Promise<void> {
 
   const athenaExecutor = new AthenaQueryExecutor(athenaService, (msg) => script.logger.info(msg));
 
-  // Initialize CSV Manager
-  const csvManager = new CSVManager(config.reportsFolder);
+  // Initialize CSV Manager — resolve relative paths via GOPaths so Lambda uses /tmp
+  const reportsPath = script.paths.resolvePath(config.reportsFolder, Core.GOPathType.OUTPUT) ?? config.reportsFolder;
+  const csvManager = new CSVManager(reportsPath);
 
   // Initialize Slack (optional)
   let slackNotifier: SlackNotifier | null = null;


### PR DESCRIPTION
CSVManager used a relative path that resolved to /var/task/reports (read-only on Lambda). Now resolves via script.paths so it falls under /tmp in AWS-managed environments. Also aligns the S3 upload path in the handler to use the same resolved location.