### PR TITLE
feat(send): send-dump-sqs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "send:report:dlq:build": "pnpm --filter=send-report-dlq build",
     "send:report:dlq:dev": "pnpm --filter=send-report-dlq dev",
     "send:report:dlq:prod": "pnpm --filter=send-report-dlq start",
+    "send:dump:sqs:build": "pnpm --filter=send-dump-sqs build",
+    "send:dump:sqs:dev": "pnpm --filter=send-dump-sqs dev",
+    "send:dump:sqs:prod": "pnpm --filter=send-dump-sqs start",
     "type-check": "tsc --noEmit"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,19 @@ importers:
         specifier: ^24.12.0
         version: 24.12.0
 
+  scripts/send/send-dump-sqs:
+    dependencies:
+      '@aws-sdk/client-sqs':
+        specifier: ^3.1010.0
+        version: 3.1011.0
+      '@go-automation/go-common':
+        specifier: workspace:*
+        version: link:../../../packages/go-common
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.12.0
+
   scripts/send/send-fetch-dynamodb-data:
     dependencies:
       '@go-automation/go-common':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,7 @@ importers:
     dependencies:
       '@aws-sdk/client-sqs':
         specifier: ^3.1010.0
-        version: 3.1011.0
+        version: 3.1018.0
       '@go-automation/go-common':
         specifier: workspace:*
         version: link:../../../packages/go-common

--- a/scripts/send/send-check-ecs/src/config.ts
+++ b/scripts/send/send-check-ecs/src/config.ts
@@ -22,14 +22,6 @@ export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
     aliases: ['aps'],
   },
   {
-    name: 'aws.region',
-    type: Core.GOConfigParameterType.STRING,
-    description: 'AWS region (default: eu-south-1)',
-    required: false,
-    aliases: ['r'],
-    defaultValue: 'eu-south-1',
-  },
-  {
     name: 'ecs.clusters',
     type: Core.GOConfigParameterType.STRING_ARRAY,
     description: 'Specific clusters to check. If empty, checks all.',

--- a/scripts/send/send-check-ecs/src/main.ts
+++ b/scripts/send/send-check-ecs/src/main.ts
@@ -1,4 +1,4 @@
-import { AWS, Core } from '@go-automation/go-common';
+import { Core } from '@go-automation/go-common';
 
 import { displayClusterReport } from './libs/ECSReportDisplay.js';
 import { ECSService } from './libs/ECSService.js';
@@ -13,11 +13,8 @@ import type { SendCheckEcsConfig } from './types/index.js';
  */
 export async function main(script: Core.GOScript): Promise<void> {
   const config = await script.getConfiguration<SendCheckEcsConfig>();
-  const region = config.awsRegion ?? AWS.AWS_REGION;
 
   script.logger.section('ECS Check');
-  script.logger.info(`Profiles: ${config.awsProfiles.join(', ')}`);
-  script.logger.info(`Region: ${region}`);
   if (config.ecsClusters && config.ecsClusters.length > 0) {
     script.logger.info(`Target Clusters: ${config.ecsClusters.join(', ')}`);
   } else {
@@ -25,15 +22,10 @@ export async function main(script: Core.GOScript): Promise<void> {
   }
   script.logger.newline();
 
-  const multiProvider = new AWS.AWSMultiClientProvider({
-    profiles: config.awsProfiles,
-    region,
-  });
-
   try {
     script.prompt.spin('fetch', 'Fetching ECS data from all profiles...');
 
-    const { results, errors } = await multiProvider.mapParallelSettled(async (_, clientProvider) => {
+    const { results, errors } = await script.awsMulti.mapParallelSettled(async (_, clientProvider) => {
       const ecsService = new ECSService(clientProvider.ecs);
 
       const clusterArns = await ecsService.listClusters(config.ecsClusters);
@@ -70,7 +62,7 @@ export async function main(script: Core.GOScript): Promise<void> {
     }
 
     script.logger.success('All checks completed.');
-  } finally {
-    multiProvider.close();
+  } catch (error) {
+    throw error;
   }
 }

--- a/scripts/send/send-check-ecs/src/main.ts
+++ b/scripts/send/send-check-ecs/src/main.ts
@@ -22,47 +22,43 @@ export async function main(script: Core.GOScript): Promise<void> {
   }
   script.logger.newline();
 
-  try {
-    script.prompt.spin('fetch', 'Fetching ECS data from all profiles...');
+  script.prompt.spin('fetch', 'Fetching ECS data from all profiles...');
 
-    const { results, errors } = await script.awsMulti.mapParallelSettled(async (_, clientProvider) => {
-      const ecsService = new ECSService(clientProvider.ecs);
+  const { results, errors } = await script.awsMulti.mapParallelSettled(async (_, clientProvider) => {
+    const ecsService = new ECSService(clientProvider.ecs);
 
-      const clusterArns = await ecsService.listClusters(config.ecsClusters);
-      const reports = await Promise.all(clusterArns.map(async (arn) => ecsService.checkCluster(arn)));
+    const clusterArns = await ecsService.listClusters(config.ecsClusters);
+    const reports = await Promise.all(clusterArns.map(async (arn) => ecsService.checkCluster(arn)));
 
-      return reports;
-    });
+    return reports;
+  });
 
-    script.prompt.spinSucceed('fetch', `Data fetched from ${results.size} profile${results.size > 1 ? 's' : ''}`);
-    script.logger.newline();
+  script.prompt.spinSucceed('fetch', `Data fetched from ${results.size} profile${results.size > 1 ? 's' : ''}`);
+  script.logger.newline();
 
-    // Display per-profile results
-    for (const [profile, reports] of results) {
-      script.logger.section(`Profile: ${profile}`);
-      if (reports.length === 0) {
-        script.logger.info('No clusters found matching criteria.');
-      } else {
-        for (const report of reports) {
-          displayClusterReport(script, report);
-          script.logger.newline();
-        }
+  // Display per-profile results
+  for (const [profile, reports] of results) {
+    script.logger.section(`Profile: ${profile}`);
+    if (reports.length === 0) {
+      script.logger.info('No clusters found matching criteria.');
+    } else {
+      for (const report of reports) {
+        displayClusterReport(script, report);
+        script.logger.newline();
       }
     }
-
-    // Report failed profiles
-    for (const [profile, error] of errors) {
-      script.logger.section(`Profile: ${profile}`);
-      script.logger.error(`Failed: ${error.message}`);
-      script.logger.newline();
-    }
-
-    if (results.size === 0 && errors.size > 0) {
-      throw new Error('All profiles failed. Check AWS credentials and profile names.');
-    }
-
-    script.logger.success('All checks completed.');
-  } catch (error) {
-    throw error;
   }
+
+  // Report failed profiles
+  for (const [profile, error] of errors) {
+    script.logger.section(`Profile: ${profile}`);
+    script.logger.error(`Failed: ${error.message}`);
+    script.logger.newline();
+  }
+
+  if (results.size === 0 && errors.size > 0) {
+    throw new Error('All profiles failed. Check AWS credentials and profile names.');
+  }
+
+  script.logger.success('All checks completed.');
 }

--- a/scripts/send/send-check-ecs/src/types/SendCheckEcsConfig.ts
+++ b/scripts/send/send-check-ecs/src/types/SendCheckEcsConfig.ts
@@ -1,5 +1,4 @@
 export interface SendCheckEcsConfig {
   readonly awsProfiles: ReadonlyArray<string>;
-  readonly awsRegion?: string;
   readonly ecsClusters?: ReadonlyArray<string>;
 }

--- a/scripts/send/send-dump-sqs/README.md
+++ b/scripts/send/send-dump-sqs/README.md
@@ -1,0 +1,90 @@
+# SEND Dump SQS
+
+> Versione: 1.1.0 | Autore: Team GO
+
+Script che effettua il dump di tutti i messaggi presenti in una coda **SQS** in formato **NDJSON**. Lo script opera in modalità **read-only**: i messaggi vengono ricevuti ma **NON** vengono eliminati dalla coda.
+
+## Indice
+
+- [Come funziona](#come-funziona)
+- [Prerequisiti](#prerequisiti)
+- [Parametri](#parametri)
+- [Deduplicazione](#deduplicazione)
+- [Utilizzo](#utilizzo)
+- [Limitazioni Importanti](#limitazioni-importanti)
+
+---
+
+## Come funziona
+
+1. **Inizializzazione** — Recupera l'URL e gli attributi della coda (dimensione, tipo FIFO). Mostra un warning se la dimensione supera i limiti di messaggi "in-flight" di SQS.
+2. **Long Polling** — Utilizza il long polling (20 secondi) per ridurre le risposte vuote e interrogare tutti i server SQS distribuite.
+3. **Ricezione e Deduplicazione** — Riceve messaggi in batch e applica la logica di deduplicazione scelta (default: `message-id`).
+4. **Export NDJSON** — Ogni messaggio unico viene salvato in una riga del file di output.
+5. **Terminazione Robusta** — Lo script termina solo dopo un numero configurabile di risposte vuote consecutive (default: 3), per garantire di aver scansionato l'intera coda.
+
+---
+
+## Prerequisiti
+
+### Software
+
+| Software | Versione minima | Note            |
+| -------- | --------------- | --------------- |
+| Node.js  | >= 22.0.0       | LTS consigliata |
+| pnpm     | >= 10.0.0       | Package manager |
+
+### Credenziali AWS
+
+La sessione SSO deve essere attiva per il profilo AWS utilizzato.
+
+---
+
+## Parametri
+
+| Parametro              | Alias   | Tipo     | Obbligatorio | Default      | Descrizione                                                                 |
+| ---------------------- | ------- | -------- | ------------ | ------------ | --------------------------------------------------------------------------- |
+| `--queue-name`         | `--qn`  | `string` | Sì           | —            | Nome della coda SQS                                                         |
+| `--visibility-timeout` | `--vt`  | `number` | No           | `30`         | Timeout di visibilità per i messaggi ricevuti                               |
+| `--limit`              | `-l`    | `number` | No           | —            | Numero massimo di messaggi da scaricare                                     |
+| `--dedup-mode`         | `--dm`  | `enum`   | No           | `message-id` | Modalità di deduplicazione (`message-id`, `content-md5`, `none`)            |
+| `--max-empty-receives` | `--mer` | `number` | No           | `3`          | Poll vuoti consecutivi prima di fermarsi                                    |
+| `--output-file`        | `-o`    | `string` | No           | —            | Percorso personalizzato del file di output (relativo a `data/` o assoluto)  |
+
+---
+
+## Deduplicazione
+
+Dato che i messaggi non vengono eliminati, lo script potrebbe ricevere lo stesso messaggio più volte se il `visibility-timeout` scade prima della fine del dump.
+
+- **`message-id`** (Default): Filtra i duplicati tecnici. Se lo stesso identico messaggio SQS viene ricevuto due volte, viene salvato solo una volta.
+- **`content-md5`**: Filtra i duplicati di contenuto. Se ci sono messaggi diversi con lo stesso corpo e attributi, viene salvato solo il primo incontrato.
+- **`none`**: Nessun filtro. Ogni messaggio ricevuto viene scritto nel file.
+
+---
+
+## Limitazioni Importanti
+
+- **In-Flight Messages**: SQS ha un limite di messaggi "in-flight" (ricevuti ma non eliminati): **120.000** per code standard, **20.000** per code FIFO. Se il dump supera questi limiti, SQS smetterà di restituire messaggi finché i timeout di visibilità non scadono.
+- **Deduplicazione in Memoria**: La deduplicazione avviene in memoria RAM. Per dump di milioni di messaggi, monitorare l'utilizzo della memoria.
+- **Standard vs FIFO**: Nelle code standard l'ordinamento non è garantito e la deduplicazione `content-md5` potrebbe non essere deterministica se i messaggi variano leggermente.
+
+---
+
+## Utilizzo
+
+```bash
+# Dump standard con deduplicazione per MessageId
+pnpm --filter=send-dump-sqs start --qn la-mia-coda --aws-profile mio-profilo
+
+# Dump con filtro sul contenuto (MD5)
+pnpm --filter=send-dump-sqs start --qn la-mia-coda --dm content-md5
+
+# Dump veloce con limite di messaggi
+pnpm --filter=send-dump-sqs start --qn la-mia-coda -l 1000
+```
+
+---
+
+**Ultima modifica**: 2026-03-27
+**Maintainer**: Team SEND

--- a/scripts/send/send-dump-sqs/README.md
+++ b/scripts/send/send-dump-sqs/README.md
@@ -46,16 +46,16 @@ aws sso login --profile <nome-profilo>
 
 ## Parametri
 
-| Parametro              | Alias   | Tipo     | Obbligatorio | Default      | Descrizione                                                                 |
-| ---------------------- | ------- | -------- | ------------ | ------------ | --------------------------------------------------------------------------- |
-| `--aws-profile`        | `--ap`  | `string` | Sì           | —            | Nome del profilo AWS SSO                                                    |
-| `--aws-region`         | `-r`    | `string` | No           | `eu-south-1` | Regione AWS                                                                 |
-| `--queue-name`         | `--qn`  | `string` | Sì           | —            | Nome della coda SQS                                                         |
-| `--visibility-timeout` | `--vt`  | `number` | No           | `30`         | Timeout di visibilità per i messaggi ricevuti                               |
-| `--limit`              | `-l`    | `number` | No           | —            | Numero massimo di messaggi da scaricare                                     |
-| `--dedup-mode`         | `--dm`  | `enum`   | No           | `message-id` | Modalità di deduplicazione (`message-id`, `content-md5`, `none`)            |
-| `--max-empty-receives` | `--mer` | `number` | No           | `3`          | Poll vuoti consecutivi prima di fermarsi                                    |
-| `--output-file`        | `-o`    | `string` | No           | —            | Percorso personalizzato del file di output (relativo a `data/` o assoluto)  |
+| Parametro              | Alias   | Tipo     | Obbligatorio | Default      | Descrizione                                                                |
+| ---------------------- | ------- | -------- | ------------ | ------------ | -------------------------------------------------------------------------- |
+| `--aws-profile`        | `--ap`  | `string` | Sì           | —            | Nome del profilo AWS SSO                                                   |
+| `--aws-region`         | `-r`    | `string` | No           | `eu-south-1` | Regione AWS                                                                |
+| `--queue-name`         | `--qn`  | `string` | Sì           | —            | Nome della coda SQS                                                        |
+| `--visibility-timeout` | `--vt`  | `number` | No           | `30`         | Timeout di visibilità per i messaggi ricevuti                              |
+| `--limit`              | `-l`    | `number` | No           | —            | Numero massimo di messaggi da scaricare                                    |
+| `--dedup-mode`         | `--dm`  | `enum`   | No           | `message-id` | Modalità di deduplicazione (`message-id`, `content-md5`, `none`)           |
+| `--max-empty-receives` | `--mer` | `number` | No           | `3`          | Poll vuoti consecutivi prima di fermarsi                                   |
+| `--output-file`        | `-o`    | `string` | No           | —            | Percorso personalizzato del file di output (relativo a `data/` o assoluto) |
 
 ---
 

--- a/scripts/send/send-dump-sqs/README.md
+++ b/scripts/send/send-dump-sqs/README.md
@@ -17,7 +17,7 @@ Script che effettua il dump di tutti i messaggi presenti in una coda **SQS** in 
 
 ## Come funziona
 
-1. **Inizializzazione** — Recupera l'URL e gli attributi della coda (dimensione, tipo FIFO). Mostra un warning se la dimensione supera i limiti di messaggi "in-flight" di SQS.
+1. **Inizializzazione** — Recupera l'URL e gli attributi della coda (dimensione, tipo FIFO) utilizzando il profilo e la regione specificati. Mostra un warning se la dimensione supera i limiti di messaggi "in-flight" di SQS.
 2. **Long Polling** — Utilizza il long polling (20 secondi) per ridurre le risposte vuote e interrogare tutti i server SQS distribuite.
 3. **Ricezione e Deduplicazione** — Riceve messaggi in batch e applica la logica di deduplicazione scelta (default: `message-id`).
 4. **Export NDJSON** — Ogni messaggio unico viene salvato in una riga del file di output.
@@ -38,12 +38,18 @@ Script che effettua il dump di tutti i messaggi presenti in una coda **SQS** in 
 
 La sessione SSO deve essere attiva per il profilo AWS utilizzato.
 
+```bash
+aws sso login --profile <nome-profilo>
+```
+
 ---
 
 ## Parametri
 
 | Parametro              | Alias   | Tipo     | Obbligatorio | Default      | Descrizione                                                                 |
 | ---------------------- | ------- | -------- | ------------ | ------------ | --------------------------------------------------------------------------- |
+| `--aws-profile`        | `--ap`  | `string` | Sì           | —            | Nome del profilo AWS SSO                                                    |
+| `--aws-region`         | `-r`    | `string` | No           | `eu-south-1` | Regione AWS                                                                 |
 | `--queue-name`         | `--qn`  | `string` | Sì           | —            | Nome della coda SQS                                                         |
 | `--visibility-timeout` | `--vt`  | `number` | No           | `30`         | Timeout di visibilità per i messaggi ricevuti                               |
 | `--limit`              | `-l`    | `number` | No           | —            | Numero massimo di messaggi da scaricare                                     |
@@ -78,13 +84,13 @@ Dato che i messaggi non vengono eliminati, lo script potrebbe ricevere lo stesso
 pnpm --filter=send-dump-sqs start --qn la-mia-coda --aws-profile mio-profilo
 
 # Dump con filtro sul contenuto (MD5)
-pnpm --filter=send-dump-sqs start --qn la-mia-coda --dm content-md5
+pnpm --filter=send-dump-sqs start --qn la-mia-coda --dm content-md5 --aws-profile mio-profilo
 
 # Dump veloce con limite di messaggi
-pnpm --filter=send-dump-sqs start --qn la-mia-coda -l 1000
+pnpm --filter=send-dump-sqs start --qn la-mia-coda -l 1000 --aws-profile mio-profilo
 ```
 
 ---
 
 **Ultima modifica**: 2026-03-27
-**Maintainer**: Team SEND
+**Maintainer**: Team GO - Gestione Operativa

--- a/scripts/send/send-dump-sqs/package.json
+++ b/scripts/send/send-dump-sqs/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "send-dump-sqs",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Read-only dump of all messages from an SQS queue in NDJSON format.",
+  "main": "dist/index.js",
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "pnpm build && node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "watch": "tsc --watch",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "keywords": [
+    "send",
+    "go-automation",
+    "sqs"
+  ],
+  "author": "Team GO - Gestione Operativa",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-sdk/client-sqs": "^3.1010.0",
+    "@go-automation/go-common": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0"
+  }
+}

--- a/scripts/send/send-dump-sqs/src/config.ts
+++ b/scripts/send/send-dump-sqs/src/config.ts
@@ -27,13 +27,27 @@ export const scriptMetadata: Core.GOScriptMetadata = {
   name: 'SEND Dump SQS',
   version: '1.1.0',
   description: 'Read-only dump of all messages from an SQS queue in NDJSON format.',
-  authors: ['Team GO'],
+  authors: ['Team GO - Gestione Operativa'],
 };
 
 /**
  * Script parameter definitions
  */
 export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
+  {
+    name: 'aws.profile',
+    type: Core.GOConfigParameterType.STRING,
+    description: 'AWS SSO profile name',
+    required: true,
+    aliases: ['ap'],
+  },
+  {
+    name: 'aws.region',
+    type: Core.GOConfigParameterType.STRING,
+    description: 'AWS region (default: eu-south-1)',
+    required: false,
+    aliases: ['r'],
+  },
   {
     name: 'queue.name',
     type: Core.GOConfigParameterType.STRING,
@@ -44,10 +58,10 @@ export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
   {
     name: 'visibility.timeout',
     type: Core.GOConfigParameterType.INT,
-    description: 'Visibility timeout for received messages in seconds (default: 30)',
+    description: 'Visibility timeout for received messages in seconds (default: 60)',
     required: false,
     aliases: ['vt'],
-    defaultValue: 30,
+    defaultValue: 60,
   },
   {
     name: 'limit',
@@ -85,6 +99,12 @@ export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
  * Script configuration interface
  */
 export interface SendDumpSqsConfig {
+  /** AWS SSO profile name */
+  readonly awsProfile: string;
+
+  /** AWS region */
+  readonly awsRegion: string | undefined;
+
   /** Target SQS queue name */
   readonly queueName: string;
 

--- a/scripts/send/send-dump-sqs/src/config.ts
+++ b/scripts/send/send-dump-sqs/src/config.ts
@@ -42,13 +42,6 @@ export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
     aliases: ['ap'],
   },
   {
-    name: 'aws.region',
-    type: Core.GOConfigParameterType.STRING,
-    description: 'AWS region (default: eu-south-1)',
-    required: false,
-    aliases: ['r'],
-  },
-  {
     name: 'queue.name',
     type: Core.GOConfigParameterType.STRING,
     description: 'Target SQS queue name',
@@ -101,9 +94,6 @@ export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
 export interface SendDumpSqsConfig {
   /** AWS SSO profile name */
   readonly awsProfile: string;
-
-  /** AWS region */
-  readonly awsRegion: string | undefined;
 
   /** Target SQS queue name */
   readonly queueName: string;

--- a/scripts/send/send-dump-sqs/src/config.ts
+++ b/scripts/send/send-dump-sqs/src/config.ts
@@ -1,0 +1,105 @@
+/**
+ * SEND Dump SQS - Configuration Module
+ *
+ * Contains script metadata, parameters definition, and configuration interface.
+ */
+
+import { Core } from '@go-automation/go-common';
+
+/**
+ * Supported deduplication modes
+ */
+export enum SendDumpSqsDedupMode {
+  /** Filter technical duplicates (same SQS message ID) */
+  MESSAGE_ID = 'message-id',
+
+  /** Filter content duplicates (same MD5 hash of Body + MessageAttributes) */
+  CONTENT_MD5 = 'content-md5',
+
+  /** No deduplication, dump everything as received */
+  NONE = 'none',
+}
+
+/**
+ * Script metadata
+ */
+export const scriptMetadata: Core.GOScriptMetadata = {
+  name: 'SEND Dump SQS',
+  version: '1.1.0',
+  description: 'Read-only dump of all messages from an SQS queue in NDJSON format.',
+  authors: ['Team GO'],
+};
+
+/**
+ * Script parameter definitions
+ */
+export const scriptParameters: ReadonlyArray<Core.GOConfigParameterOptions> = [
+  {
+    name: 'queue.name',
+    type: Core.GOConfigParameterType.STRING,
+    description: 'Target SQS queue name',
+    required: true,
+    aliases: ['qn'],
+  },
+  {
+    name: 'visibility.timeout',
+    type: Core.GOConfigParameterType.INT,
+    description: 'Visibility timeout for received messages in seconds (default: 30)',
+    required: false,
+    aliases: ['vt'],
+    defaultValue: 30,
+  },
+  {
+    name: 'limit',
+    type: Core.GOConfigParameterType.INT,
+    description: 'Maximum number of messages to dump',
+    required: false,
+    aliases: ['l'],
+  },
+  {
+    name: 'dedup.mode',
+    type: Core.GOConfigParameterType.STRING,
+    description: 'Deduplication mode (message-id, content-md5, none) (default: message-id)',
+    required: false,
+    aliases: ['dm'],
+    defaultValue: SendDumpSqsDedupMode.MESSAGE_ID,
+  },
+  {
+    name: 'max.empty.receives',
+    type: Core.GOConfigParameterType.INT,
+    description: 'Number of consecutive empty polls before stopping (default: 3)',
+    required: false,
+    aliases: ['mer'],
+    defaultValue: 3,
+  },
+  {
+    name: 'output.file',
+    type: Core.GOConfigParameterType.STRING,
+    description: 'Custom output file path (relative to project root or absolute)',
+    required: false,
+    aliases: ['o'],
+  },
+] as const;
+
+/**
+ * Script configuration interface
+ */
+export interface SendDumpSqsConfig {
+  /** Target SQS queue name */
+  readonly queueName: string;
+
+  /** Visibility timeout for received messages */
+  readonly visibilityTimeout: number;
+
+  /** Maximum number of messages to dump */
+  readonly limit: number | undefined;
+
+  /** Deduplication mode */
+  readonly dedupMode: SendDumpSqsDedupMode;
+
+  /** Number of consecutive empty polls before stopping */
+  readonly maxEmptyReceives: number;
+
+  /** Custom output file path */
+  readonly outputFile: string | undefined;
+}

--- a/scripts/send/send-dump-sqs/src/index.ts
+++ b/scripts/send/send-dump-sqs/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * SEND Dump SQS - Entry Point
+ *
+ * Minimal entry point that wires together:
+ * - GOScript instantiation with metadata and parameters
+ * - Configuration loading and validation
+ * - Main business logic execution
+ */
+
+import { Core } from '@go-automation/go-common';
+
+import { scriptMetadata, scriptParameters } from './config.js';
+import { main } from './main.js';
+
+/**
+ * Create the GOScript instance with metadata and parameters from config
+ */
+const script = new Core.GOScript({
+  metadata: scriptMetadata,
+  config: {
+    parameters: scriptParameters,
+  },
+});
+
+/**
+ * Run the script with lifecycle management
+ */
+script
+  .run(async () => {
+    await main(script);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/send/send-dump-sqs/src/main.ts
+++ b/scripts/send/send-dump-sqs/src/main.ts
@@ -56,161 +56,154 @@ export async function main(script: Core.GOScript): Promise<void> {
 
   const sqsClient = script.aws.sqs;
 
+  // Get Queue URL and Attributes
+  script.prompt.spin('init', `Initializing dump for queue "${config.queueName}"...`);
+  let queueUrl: string;
   try {
-    // Get Queue URL and Attributes
-    script.prompt.spin('init', `Initializing dump for queue "${config.queueName}"...`);
-    let queueUrl: string;
-    try {
-      const getUrlResponse = await sqsClient.send(new GetQueueUrlCommand({ QueueName: config.queueName }));
-      if (getUrlResponse.QueueUrl === undefined) {
-        throw new Error(`Queue URL not found for "${config.queueName}"`);
-      }
-      queueUrl = getUrlResponse.QueueUrl;
+    const getUrlResponse = await sqsClient.send(new GetQueueUrlCommand({ QueueName: config.queueName }));
+    if (getUrlResponse.QueueUrl === undefined) {
+      throw new Error(`Queue URL not found for "${config.queueName}"`);
+    }
+    queueUrl = getUrlResponse.QueueUrl;
 
-      const isFifoByName = config.queueName.endsWith('.fifo');
-      const attributeNames: QueueAttributeName[] = ['ApproximateNumberOfMessages'];
-      if (isFifoByName) {
-        attributeNames.push('FifoQueue');
-      }
-
-      const getAttrResponse = await sqsClient.send(
-        new GetQueueAttributesCommand({
-          QueueUrl: queueUrl,
-          AttributeNames: attributeNames,
-        }),
-      );
-
-      const isFifo = isFifoByName || getAttrResponse.Attributes?.FifoQueue === 'true';
-      const approxMessages = parseInt(getAttrResponse.Attributes?.ApproximateNumberOfMessages ?? '0', 10);
-      const inFlightLimit = isFifo ? 20000 : 120000;
-
-      script.prompt.spinSucceed(
-        'init',
-        `Queue initialized. Approx. messages: ${approxMessages}${isFifo ? ' (FIFO)' : ''}`,
-      );
-
-      if (approxMessages > inFlightLimit) {
-        script.logger.warning(
-          `Queue size (${approxMessages}) exceeds SQS in-flight message limit (${inFlightLimit}). ` +
-            'Dumping without deleting will stop once the limit is reached.',
-        );
-      }
-    } catch (error) {
-      script.prompt.spinFail(
-        'init',
-        `Failed to initialize queue: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      throw error;
+    const isFifoByName = config.queueName.endsWith('.fifo');
+    const attributeNames: QueueAttributeName[] = ['ApproximateNumberOfMessages'];
+    if (isFifoByName) {
+      attributeNames.push('FifoQueue');
     }
 
-    // Dump loop state
-    let totalReceived = 0;
-    let totalDumped = 0;
-    let totalDuplicates = 0;
-    let consecutiveEmptyReceives = 0;
-    const seenKeys = new Set<string>();
-
-    script.prompt.startSpinner('Dumping messages...');
-
-    while (consecutiveEmptyReceives < config.maxEmptyReceives) {
-      // Check limit
-      if (config.limit !== undefined && totalDumped >= config.limit) {
-        break;
-      }
-
-      // Calculate next batch size
-      let nextBatchSize = MAX_BATCH_SIZE;
-      if (config.limit !== undefined) {
-        const remaining = config.limit - totalDumped;
-        nextBatchSize = Math.min(MAX_BATCH_SIZE, remaining);
-      }
-
-      const receiveResponse = await sqsClient.send(
-        new ReceiveMessageCommand({
-          QueueUrl: queueUrl,
-          MaxNumberOfMessages: nextBatchSize,
-          VisibilityTimeout: config.visibilityTimeout,
-          WaitTimeSeconds: WAIT_TIME_SECONDS,
-          AttributeNames: ['All'],
-          MessageAttributeNames: ['All'],
-        }),
-      );
-
-      const messages = receiveResponse.Messages ?? [];
-
-      if (messages.length === 0) {
-        consecutiveEmptyReceives++;
-        script.prompt.updateSpinner(
-          `Empty receive (${consecutiveEmptyReceives}/${config.maxEmptyReceives})... Still searching...`,
-        );
-        continue;
-      }
-
-      // Process messages and count unique
-      let newMessagesInBatch = 0;
-      for (const message of messages) {
-        let isDuplicate = false;
-
-        if (config.dedupMode !== SendDumpSqsDedupMode.NONE) {
-          let dedupKey: string | undefined;
-
-          if (config.dedupMode === SendDumpSqsDedupMode.MESSAGE_ID) {
-            dedupKey = message.MessageId;
-          } else if (config.dedupMode === SendDumpSqsDedupMode.CONTENT_MD5) {
-            dedupKey = `${message.MD5OfBody ?? ''}:${message.MD5OfMessageAttributes ?? ''}`;
-          }
-
-          if (dedupKey !== undefined) {
-            if (seenKeys.has(dedupKey)) {
-              isDuplicate = true;
-            } else {
-              seenKeys.add(dedupKey);
-            }
-          }
-        }
-
-        if (isDuplicate) {
-          totalDuplicates++;
-        } else {
-          // Append to NDJSON file
-          fs.appendFileSync(outputPathInfo.path, `${JSON.stringify(message)}\n`, 'utf-8');
-          totalDumped++;
-          newMessagesInBatch++;
-        }
-      }
-
-      totalReceived += messages.length;
-
-      if (newMessagesInBatch > 0) {
-        // Reset empty counter only if we found NEW unique messages
-        consecutiveEmptyReceives = 0;
-      } else {
-        // If we got messages but all were duplicates, treat it as a "non-productive" poll
-        consecutiveEmptyReceives++;
-        script.prompt.updateSpinner(
-          `Only duplicates received (${consecutiveEmptyReceives}/${config.maxEmptyReceives})... Still searching...`,
-        );
-      }
-
-      script.prompt.updateSpinner(
-        `Dumped: ${totalDumped} | Received: ${totalReceived} | Duplicates: ${totalDuplicates}`,
-      );
-    }
-
-    const stopReason =
-      config.limit !== undefined && totalDumped >= config.limit
-        ? 'reached limit'
-        : `queue empty after ${config.maxEmptyReceives} polls`;
-
-    script.prompt.spinnerStop(
-      `Dump completed (${stopReason}).\n` +
-        `  - Total unique messages: ${totalDumped}\n` +
-        `  - Total messages received: ${totalReceived}\n` +
-        `  - Duplicates filtered: ${totalDuplicates}\n` +
-        `  - File: ${outputPathInfo.path}`,
+    const getAttrResponse = await sqsClient.send(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: attributeNames,
+      }),
     );
+
+    const isFifo = isFifoByName || getAttrResponse.Attributes?.FifoQueue === 'true';
+    const approxMessages = parseInt(getAttrResponse.Attributes?.ApproximateNumberOfMessages ?? '0', 10);
+    const inFlightLimit = isFifo ? 20000 : 120000;
+
+    script.prompt.spinSucceed(
+      'init',
+      `Queue initialized. Approx. messages: ${approxMessages}${isFifo ? ' (FIFO)' : ''}`,
+    );
+
+    if (approxMessages > inFlightLimit) {
+      script.logger.warning(
+        `Queue size (${approxMessages}) exceeds SQS in-flight message limit (${inFlightLimit}). ` +
+          'Dumping without deleting will stop once the limit is reached.',
+      );
+    }
   } catch (error) {
-    script.logger.error(`Error during dump: ${error instanceof Error ? error.message : String(error)}`);
+    script.prompt.spinFail(
+      'init',
+      `Failed to initialize queue: ${error instanceof Error ? error.message : String(error)}`,
+    );
     throw error;
   }
+
+  // Dump loop state
+  let totalReceived = 0;
+  let totalDumped = 0;
+  let totalDuplicates = 0;
+  let consecutiveEmptyReceives = 0;
+  const seenKeys = new Set<string>();
+
+  script.prompt.startSpinner('Dumping messages...');
+
+  while (consecutiveEmptyReceives < config.maxEmptyReceives) {
+    // Check limit
+    if (config.limit !== undefined && totalDumped >= config.limit) {
+      break;
+    }
+
+    // Calculate next batch size
+    let nextBatchSize = MAX_BATCH_SIZE;
+    if (config.limit !== undefined) {
+      const remaining = config.limit - totalDumped;
+      nextBatchSize = Math.min(MAX_BATCH_SIZE, remaining);
+    }
+
+    const receiveResponse = await sqsClient.send(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: nextBatchSize,
+        VisibilityTimeout: config.visibilityTimeout,
+        WaitTimeSeconds: WAIT_TIME_SECONDS,
+        AttributeNames: ['All'],
+        MessageAttributeNames: ['All'],
+      }),
+    );
+
+    const messages = receiveResponse.Messages ?? [];
+
+    if (messages.length === 0) {
+      consecutiveEmptyReceives++;
+      script.prompt.updateSpinner(
+        `Empty receive (${consecutiveEmptyReceives}/${config.maxEmptyReceives})... Still searching...`,
+      );
+      continue;
+    }
+
+    // Process messages and count unique
+    let newMessagesInBatch = 0;
+    for (const message of messages) {
+      let isDuplicate = false;
+
+      if (config.dedupMode !== SendDumpSqsDedupMode.NONE) {
+        let dedupKey: string | undefined;
+
+        if (config.dedupMode === SendDumpSqsDedupMode.MESSAGE_ID) {
+          dedupKey = message.MessageId;
+        } else if (config.dedupMode === SendDumpSqsDedupMode.CONTENT_MD5) {
+          dedupKey = `${message.MD5OfBody ?? ''}:${message.MD5OfMessageAttributes ?? ''}`;
+        }
+
+        if (dedupKey !== undefined) {
+          if (seenKeys.has(dedupKey)) {
+            isDuplicate = true;
+          } else {
+            seenKeys.add(dedupKey);
+          }
+        }
+      }
+
+      if (isDuplicate) {
+        totalDuplicates++;
+      } else {
+        // Append to NDJSON file
+        fs.appendFileSync(outputPathInfo.path, `${JSON.stringify(message)}\n`, 'utf-8');
+        totalDumped++;
+        newMessagesInBatch++;
+      }
+    }
+
+    totalReceived += messages.length;
+
+    if (newMessagesInBatch > 0) {
+      // Reset empty counter only if we found NEW unique messages
+      consecutiveEmptyReceives = 0;
+    } else {
+      // If we got messages but all were duplicates, treat it as a "non-productive" poll
+      consecutiveEmptyReceives++;
+      script.prompt.updateSpinner(
+        `Only duplicates received (${consecutiveEmptyReceives}/${config.maxEmptyReceives})... Still searching...`,
+      );
+    }
+
+    script.prompt.updateSpinner(`Dumped: ${totalDumped} | Received: ${totalReceived} | Duplicates: ${totalDuplicates}`);
+  }
+
+  const stopReason =
+    config.limit !== undefined && totalDumped >= config.limit
+      ? 'reached limit'
+      : `queue empty after ${config.maxEmptyReceives} polls`;
+
+  script.prompt.spinnerStop(
+    `Dump completed (${stopReason}).\n` +
+      `  - Total unique messages: ${totalDumped}\n` +
+      `  - Total messages received: ${totalReceived}\n` +
+      `  - Duplicates filtered: ${totalDuplicates}\n` +
+      `  - File: ${outputPathInfo.path}`,
+  );
 }

--- a/scripts/send/send-dump-sqs/src/main.ts
+++ b/scripts/send/send-dump-sqs/src/main.ts
@@ -17,9 +17,8 @@ import {
   ReceiveMessageCommand,
   type QueueAttributeName,
 } from '@aws-sdk/client-sqs';
-import { AWS, Core } from '@go-automation/go-common';
+import { Core } from '@go-automation/go-common';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 import { SendDumpSqsDedupMode, type SendDumpSqsConfig } from './config.js';
 
@@ -36,14 +35,6 @@ export async function main(script: Core.GOScript): Promise<void> {
   const config = await script.getConfiguration<SendDumpSqsConfig>();
 
   script.logger.section('SEND Dump SQS');
-  script.logger.info(`Profile: ${config.awsProfile}`);
-  script.logger.info(`Region: ${config.awsRegion}`);
-  script.logger.info(`Queue: ${config.queueName}`);
-  script.logger.info(`Visibility Timeout: ${config.visibilityTimeout}s`);
-  script.logger.info(`Deduplication Mode: ${config.dedupMode}`);
-  if (config.limit !== undefined) {
-    script.logger.info(`Limit: ${config.limit} messages`);
-  }
 
   // Warning if visibility timeout is too short compared to polling strategy
   const pollingWindow = WAIT_TIME_SECONDS * config.maxEmptyReceives;
@@ -60,26 +51,10 @@ export async function main(script: Core.GOScript): Promise<void> {
   const outputFile = config.outputFile ?? defaultOutputFile;
   const outputPathInfo = script.paths.resolvePathWithInfo(outputFile, Core.GOPathType.OUTPUT);
 
-  // Ensure output directory exists
-  const outputDir = path.dirname(outputPathInfo.path);
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
-  }
-
   script.logger.info(`Output file: ${outputPathInfo.path}`);
   script.logger.newline();
 
-  // Initialize AWS provider with specific profile and region
-  const region = config.awsRegion ?? AWS.AWS_REGION; // Ensure region is always a string
-  script.logger.info(`Region: ${region}`); // Log the determined region
-
-  const awsProviderConfig: AWS.AWSClientProviderConfig = {
-    profile: config.awsProfile,
-    region: region, // Pass the guaranteed string region
-  };
-  const awsProvider = new AWS.AWSClientProvider(awsProviderConfig);
-
-  const sqsClient = awsProvider.sqs;
+  const sqsClient = script.aws.sqs;
 
   try {
     // Get Queue URL and Attributes
@@ -237,7 +212,5 @@ export async function main(script: Core.GOScript): Promise<void> {
   } catch (error) {
     script.logger.error(`Error during dump: ${error instanceof Error ? error.message : String(error)}`);
     throw error;
-  } finally {
-    awsProvider.close();
   }
 }

--- a/scripts/send/send-dump-sqs/src/main.ts
+++ b/scripts/send/send-dump-sqs/src/main.ts
@@ -11,8 +11,13 @@
  * - Progress estimation and capacity warnings.
  */
 
-import { GetQueueAttributesCommand, GetQueueUrlCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
-import { Core } from '@go-automation/go-common';
+import {
+  GetQueueAttributesCommand,
+  GetQueueUrlCommand,
+  ReceiveMessageCommand,
+  type QueueAttributeName,
+} from '@aws-sdk/client-sqs';
+import { AWS, Core } from '@go-automation/go-common';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -29,14 +34,24 @@ const WAIT_TIME_SECONDS = 20;
  */
 export async function main(script: Core.GOScript): Promise<void> {
   const config = await script.getConfiguration<SendDumpSqsConfig>();
-  const sqsClient = script.aws.sqs;
 
   script.logger.section('SEND Dump SQS');
+  script.logger.info(`Profile: ${config.awsProfile}`);
+  script.logger.info(`Region: ${config.awsRegion}`);
   script.logger.info(`Queue: ${config.queueName}`);
   script.logger.info(`Visibility Timeout: ${config.visibilityTimeout}s`);
   script.logger.info(`Deduplication Mode: ${config.dedupMode}`);
   if (config.limit !== undefined) {
     script.logger.info(`Limit: ${config.limit} messages`);
+  }
+
+  // Warning if visibility timeout is too short compared to polling strategy
+  const pollingWindow = WAIT_TIME_SECONDS * config.maxEmptyReceives;
+  if (config.visibilityTimeout < pollingWindow) {
+    script.logger.warning(
+      `Visibility Timeout (${config.visibilityTimeout}s) is shorter than the polling window (${pollingWindow}s). ` +
+        'Messages may reappear and be received again before the dump completes.',
+    );
   }
 
   // Resolve output path
@@ -54,53 +69,74 @@ export async function main(script: Core.GOScript): Promise<void> {
   script.logger.info(`Output file: ${outputPathInfo.path}`);
   script.logger.newline();
 
-  // Get Queue URL and Attributes
-  script.prompt.spin('init', `Initializing dump for queue "${config.queueName}"...`);
-  let queueUrl: string;
+  // Initialize AWS provider with specific profile and region
+  const region = config.awsRegion ?? AWS.AWS_REGION; // Ensure region is always a string
+  script.logger.info(`Region: ${region}`); // Log the determined region
+
+  const awsProviderConfig: AWS.AWSClientProviderConfig = {
+    profile: config.awsProfile,
+    region: region, // Pass the guaranteed string region
+  };
+  const awsProvider = new AWS.AWSClientProvider(awsProviderConfig);
+
+  const sqsClient = awsProvider.sqs;
+
   try {
-    const getUrlResponse = await sqsClient.send(new GetQueueUrlCommand({ QueueName: config.queueName }));
-    if (getUrlResponse.QueueUrl === undefined) {
-      throw new Error(`Queue URL not found for "${config.queueName}"`);
-    }
-    queueUrl = getUrlResponse.QueueUrl;
+    // Get Queue URL and Attributes
+    script.prompt.spin('init', `Initializing dump for queue "${config.queueName}"...`);
+    let queueUrl: string;
+    try {
+      const getUrlResponse = await sqsClient.send(new GetQueueUrlCommand({ QueueName: config.queueName }));
+      if (getUrlResponse.QueueUrl === undefined) {
+        throw new Error(`Queue URL not found for "${config.queueName}"`);
+      }
+      queueUrl = getUrlResponse.QueueUrl;
 
-    const getAttrResponse = await sqsClient.send(
-      new GetQueueAttributesCommand({
-        QueueUrl: queueUrl,
-        AttributeNames: ['ApproximateNumberOfMessages', 'FifoQueue'],
-      }),
-    );
+      const isFifoByName = config.queueName.endsWith('.fifo');
+      const attributeNames: QueueAttributeName[] = ['ApproximateNumberOfMessages'];
+      if (isFifoByName) {
+        attributeNames.push('FifoQueue');
+      }
 
-    const isFifo = getAttrResponse.Attributes?.FifoQueue === 'true';
-    const approxMessages = parseInt(getAttrResponse.Attributes?.ApproximateNumberOfMessages ?? '0', 10);
-    const inFlightLimit = isFifo ? 20000 : 120000;
-
-    script.prompt.spinSucceed(
-      'init',
-      `Queue initialized. Approx. messages: ${approxMessages}${isFifo ? ' (FIFO)' : ''}`,
-    );
-
-    if (approxMessages > inFlightLimit) {
-      script.logger.warning(
-        `Queue size (${approxMessages}) exceeds SQS in-flight message limit (${inFlightLimit}). ` +
-          'Dumping without deleting will stop once the limit is reached.',
+      const getAttrResponse = await sqsClient.send(
+        new GetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          AttributeNames: attributeNames,
+        }),
       );
+
+      const isFifo = isFifoByName || getAttrResponse.Attributes?.FifoQueue === 'true';
+      const approxMessages = parseInt(getAttrResponse.Attributes?.ApproximateNumberOfMessages ?? '0', 10);
+      const inFlightLimit = isFifo ? 20000 : 120000;
+
+      script.prompt.spinSucceed(
+        'init',
+        `Queue initialized. Approx. messages: ${approxMessages}${isFifo ? ' (FIFO)' : ''}`,
+      );
+
+      if (approxMessages > inFlightLimit) {
+        script.logger.warning(
+          `Queue size (${approxMessages}) exceeds SQS in-flight message limit (${inFlightLimit}). ` +
+            'Dumping without deleting will stop once the limit is reached.',
+        );
+      }
+    } catch (error) {
+      script.prompt.spinFail(
+        'init',
+        `Failed to initialize queue: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
     }
-  } catch (error) {
-    script.prompt.spinFail('init', `Failed to initialize queue: ${error instanceof Error ? error.message : String(error)}`);
-    throw error;
-  }
 
-  // Dump loop state
-  let totalReceived = 0;
-  let totalDumped = 0;
-  let totalDuplicates = 0;
-  let consecutiveEmptyReceives = 0;
-  const seenKeys = new Set<string>();
+    // Dump loop state
+    let totalReceived = 0;
+    let totalDumped = 0;
+    let totalDuplicates = 0;
+    let consecutiveEmptyReceives = 0;
+    const seenKeys = new Set<string>();
 
-  script.prompt.startSpinner('Dumping messages...');
+    script.prompt.startSpinner('Dumping messages...');
 
-  try {
     while (consecutiveEmptyReceives < config.maxEmptyReceives) {
       // Check limit
       if (config.limit !== undefined && totalDumped >= config.limit) {
@@ -135,11 +171,8 @@ export async function main(script: Core.GOScript): Promise<void> {
         continue;
       }
 
-      // Reset empty counter on success
-      consecutiveEmptyReceives = 0;
-      totalReceived += messages.length;
-
-      // Process messages
+      // Process messages and count unique
+      let newMessagesInBatch = 0;
       for (const message of messages) {
         let isDuplicate = false;
 
@@ -167,10 +200,26 @@ export async function main(script: Core.GOScript): Promise<void> {
           // Append to NDJSON file
           fs.appendFileSync(outputPathInfo.path, `${JSON.stringify(message)}\n`, 'utf-8');
           totalDumped++;
+          newMessagesInBatch++;
         }
       }
 
-      script.prompt.updateSpinner(`Dumped: ${totalDumped} | Received: ${totalReceived} | Duplicates: ${totalDuplicates}`);
+      totalReceived += messages.length;
+
+      if (newMessagesInBatch > 0) {
+        // Reset empty counter only if we found NEW unique messages
+        consecutiveEmptyReceives = 0;
+      } else {
+        // If we got messages but all were duplicates, treat it as a "non-productive" poll
+        consecutiveEmptyReceives++;
+        script.prompt.updateSpinner(
+          `Only duplicates received (${consecutiveEmptyReceives}/${config.maxEmptyReceives})... Still searching...`,
+        );
+      }
+
+      script.prompt.updateSpinner(
+        `Dumped: ${totalDumped} | Received: ${totalReceived} | Duplicates: ${totalDuplicates}`,
+      );
     }
 
     const stopReason =
@@ -186,8 +235,9 @@ export async function main(script: Core.GOScript): Promise<void> {
         `  - File: ${outputPathInfo.path}`,
     );
   } catch (error) {
-    script.prompt.spinnerStop();
     script.logger.error(`Error during dump: ${error instanceof Error ? error.message : String(error)}`);
     throw error;
+  } finally {
+    awsProvider.close();
   }
 }

--- a/scripts/send/send-dump-sqs/src/main.ts
+++ b/scripts/send/send-dump-sqs/src/main.ts
@@ -1,0 +1,193 @@
+/**
+ * SEND Dump SQS - Main Logic Module
+ *
+ * Read-only dumps all messages from a specified SQS queue in NDJSON format.
+ * Messages are received but NOT deleted from the queue.
+ *
+ * Features:
+ * - Long polling (20s) for efficient message retrieval.
+ * - Deduplication modes (message-id, content-md5, none).
+ * - Multi-pass empty check to ensure queue is truly empty.
+ * - Progress estimation and capacity warnings.
+ */
+
+import { GetQueueAttributesCommand, GetQueueUrlCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { Core } from '@go-automation/go-common';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { SendDumpSqsDedupMode, type SendDumpSqsConfig } from './config.js';
+
+/** Max messages per receive (SQS limit) */
+const MAX_BATCH_SIZE = 10;
+
+/** Long polling wait time */
+const WAIT_TIME_SECONDS = 20;
+
+/**
+ * Main script execution function.
+ */
+export async function main(script: Core.GOScript): Promise<void> {
+  const config = await script.getConfiguration<SendDumpSqsConfig>();
+  const sqsClient = script.aws.sqs;
+
+  script.logger.section('SEND Dump SQS');
+  script.logger.info(`Queue: ${config.queueName}`);
+  script.logger.info(`Visibility Timeout: ${config.visibilityTimeout}s`);
+  script.logger.info(`Deduplication Mode: ${config.dedupMode}`);
+  if (config.limit !== undefined) {
+    script.logger.info(`Limit: ${config.limit} messages`);
+  }
+
+  // Resolve output path
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const defaultOutputFile = `dump_${config.queueName}_${timestamp}.ndjson`;
+  const outputFile = config.outputFile ?? defaultOutputFile;
+  const outputPathInfo = script.paths.resolvePathWithInfo(outputFile, Core.GOPathType.OUTPUT);
+
+  // Ensure output directory exists
+  const outputDir = path.dirname(outputPathInfo.path);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  script.logger.info(`Output file: ${outputPathInfo.path}`);
+  script.logger.newline();
+
+  // Get Queue URL and Attributes
+  script.prompt.spin('init', `Initializing dump for queue "${config.queueName}"...`);
+  let queueUrl: string;
+  try {
+    const getUrlResponse = await sqsClient.send(new GetQueueUrlCommand({ QueueName: config.queueName }));
+    if (getUrlResponse.QueueUrl === undefined) {
+      throw new Error(`Queue URL not found for "${config.queueName}"`);
+    }
+    queueUrl = getUrlResponse.QueueUrl;
+
+    const getAttrResponse = await sqsClient.send(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ['ApproximateNumberOfMessages', 'FifoQueue'],
+      }),
+    );
+
+    const isFifo = getAttrResponse.Attributes?.FifoQueue === 'true';
+    const approxMessages = parseInt(getAttrResponse.Attributes?.ApproximateNumberOfMessages ?? '0', 10);
+    const inFlightLimit = isFifo ? 20000 : 120000;
+
+    script.prompt.spinSucceed(
+      'init',
+      `Queue initialized. Approx. messages: ${approxMessages}${isFifo ? ' (FIFO)' : ''}`,
+    );
+
+    if (approxMessages > inFlightLimit) {
+      script.logger.warning(
+        `Queue size (${approxMessages}) exceeds SQS in-flight message limit (${inFlightLimit}). ` +
+          'Dumping without deleting will stop once the limit is reached.',
+      );
+    }
+  } catch (error) {
+    script.prompt.spinFail('init', `Failed to initialize queue: ${error instanceof Error ? error.message : String(error)}`);
+    throw error;
+  }
+
+  // Dump loop state
+  let totalReceived = 0;
+  let totalDumped = 0;
+  let totalDuplicates = 0;
+  let consecutiveEmptyReceives = 0;
+  const seenKeys = new Set<string>();
+
+  script.prompt.startSpinner('Dumping messages...');
+
+  try {
+    while (consecutiveEmptyReceives < config.maxEmptyReceives) {
+      // Check limit
+      if (config.limit !== undefined && totalDumped >= config.limit) {
+        break;
+      }
+
+      // Calculate next batch size
+      let nextBatchSize = MAX_BATCH_SIZE;
+      if (config.limit !== undefined) {
+        const remaining = config.limit - totalDumped;
+        nextBatchSize = Math.min(MAX_BATCH_SIZE, remaining);
+      }
+
+      const receiveResponse = await sqsClient.send(
+        new ReceiveMessageCommand({
+          QueueUrl: queueUrl,
+          MaxNumberOfMessages: nextBatchSize,
+          VisibilityTimeout: config.visibilityTimeout,
+          WaitTimeSeconds: WAIT_TIME_SECONDS,
+          AttributeNames: ['All'],
+          MessageAttributeNames: ['All'],
+        }),
+      );
+
+      const messages = receiveResponse.Messages ?? [];
+
+      if (messages.length === 0) {
+        consecutiveEmptyReceives++;
+        script.prompt.updateSpinner(
+          `Empty receive (${consecutiveEmptyReceives}/${config.maxEmptyReceives})... Still searching...`,
+        );
+        continue;
+      }
+
+      // Reset empty counter on success
+      consecutiveEmptyReceives = 0;
+      totalReceived += messages.length;
+
+      // Process messages
+      for (const message of messages) {
+        let isDuplicate = false;
+
+        if (config.dedupMode !== SendDumpSqsDedupMode.NONE) {
+          let dedupKey: string | undefined;
+
+          if (config.dedupMode === SendDumpSqsDedupMode.MESSAGE_ID) {
+            dedupKey = message.MessageId;
+          } else if (config.dedupMode === SendDumpSqsDedupMode.CONTENT_MD5) {
+            dedupKey = `${message.MD5OfBody ?? ''}:${message.MD5OfMessageAttributes ?? ''}`;
+          }
+
+          if (dedupKey !== undefined) {
+            if (seenKeys.has(dedupKey)) {
+              isDuplicate = true;
+            } else {
+              seenKeys.add(dedupKey);
+            }
+          }
+        }
+
+        if (isDuplicate) {
+          totalDuplicates++;
+        } else {
+          // Append to NDJSON file
+          fs.appendFileSync(outputPathInfo.path, `${JSON.stringify(message)}\n`, 'utf-8');
+          totalDumped++;
+        }
+      }
+
+      script.prompt.updateSpinner(`Dumped: ${totalDumped} | Received: ${totalReceived} | Duplicates: ${totalDuplicates}`);
+    }
+
+    const stopReason =
+      config.limit !== undefined && totalDumped >= config.limit
+        ? 'reached limit'
+        : `queue empty after ${config.maxEmptyReceives} polls`;
+
+    script.prompt.spinnerStop(
+      `Dump completed (${stopReason}).\n` +
+        `  - Total unique messages: ${totalDumped}\n` +
+        `  - Total messages received: ${totalReceived}\n` +
+        `  - Duplicates filtered: ${totalDuplicates}\n` +
+        `  - File: ${outputPathInfo.path}`,
+    );
+  } catch (error) {
+    script.prompt.spinnerStop();
+    script.logger.error(`Error during dump: ${error instanceof Error ? error.message : String(error)}`);
+    throw error;
+  }
+}

--- a/scripts/send/send-dump-sqs/tsconfig.json
+++ b/scripts/send/send-dump-sqs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "configs", "logs", "reports"],
+  "references": [
+    {
+      "path": "../../../packages/go-common"
+    }
+  ]
+}

--- a/scripts/send/send-dump-sqs/tsconfig.json
+++ b/scripts/send/send-dump-sqs/tsconfig.json
@@ -7,7 +7,7 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "configs", "logs", "reports"],
+  "exclude": ["node_modules", "dist", "configs", "reports"],
   "references": [
     {
       "path": "../../../packages/go-common"


### PR DESCRIPTION
## Description

This pull request introduces a new `send-dump-sqs` script for the SEND product. Its main focus is dumping messages from SQS queues for the purpose of further analysis on their content.

Key changes:
    * Dumps SQS messages to NDJSON files.
    * Read-only: messages are downloaded but never deleted.
    * Defaults to a `visibility-timeout` of 60 seconds.
    * Ends after 3 consecutive empty message polls every 20 seconds.
    * Deduplicates received messages by either `messageId` or `MD5` Body/Attributes.
    * Warns for short visibility timeouts that could lead to message duplication.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->
[GO-1267](https://pagopa.atlassian.net/browse/GO-1267)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (`pnpm lint`)
- [x] The build passes (`pnpm build`)
- [x] Type checking passes (`pnpm type-check`)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->


[GO-1267]: https://pagopa.atlassian.net/browse/GO-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ