### PR TITLE
Add timeout and memory size parameters for GoSendMonitorTppMessagesLambda

### DIFF
--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -8,6 +8,8 @@
     "AthenaRetryDelay": "5000",
     "SlackChannel": "C09RSL0QUTV",
     "Timezone": "Europe/Rome",
-    "SlackTokenSecretName": "go/send-monitor-tpp-messages/slack-token"
+    "SlackTokenSecretName": "go/send-monitor-tpp-messages/slack-token",
+    "GoSendMonitorTppMessagesLambdaTimeout": "300",
+    "GoSendMonitorTppMessagesLambdaMemorySize": "512"
   }
 }


### PR DESCRIPTION
## Description

Add timeout and memory size parameters to the GoSendMonitorTppMessagesLambda configuration.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
