### PR TITLE
Add preset functionality and related features

### DIFF
--- a/packages/go-common/src/libs/aws/GOAWSCredentialsManager.ts
+++ b/packages/go-common/src/libs/aws/GOAWSCredentialsManager.ts
@@ -770,6 +770,7 @@ export class GOAWSCredentialsManager {
   ): string | undefined {
     const lowerMessage = message.toLowerCase();
     let searchStart = 0;
+    const missingClosingDelimiters = new Set<string>();
 
     while (searchStart < message.length) {
       const markerIndex = lowerMessage.indexOf(PROFILE_MARKER, searchStart);
@@ -789,10 +790,17 @@ export class GOAWSCredentialsManager {
         continue;
       }
 
+      if (missingClosingDelimiters.has(closing)) {
+        searchStart = openingIndex + 1;
+        continue;
+      }
+
       const valueStart = openingIndex + 1;
       const valueEnd = message.indexOf(closing, valueStart);
       if (valueEnd === -1) {
-        return undefined;
+        missingClosingDelimiters.add(closing);
+        searchStart = openingIndex + 1;
+        continue;
       }
 
       const value = message.slice(valueStart, valueEnd);

--- a/packages/go-common/src/libs/aws/GOAWSCredentialsManager.ts
+++ b/packages/go-common/src/libs/aws/GOAWSCredentialsManager.ts
@@ -35,6 +35,7 @@ interface InternalOptions {
 }
 
 type GOAWSRetryOperationHandler<T> = () => Promise<T>;
+type GOAWSProfileClosingDelimiterResolverFn = (opening: string) => string | undefined;
 
 /**
  * Default options for the credentials manager
@@ -64,10 +65,10 @@ const SSO_SESSION_INVALID_PATTERNS: ReadonlyArray<RegExp> = [
   /The SSO session associated with this profile is invalid/i,
 ];
 
-const PROFILE_NOT_FOUND_PATTERNS: ReadonlyArray<RegExp> = [
-  /Profile .+ could not be found/i,
-  /The config profile \(.+\) could not be found/i,
-];
+const PROFILE_MARKER = 'profile ';
+const PROFILE_NOT_FOUND_SUFFIX = ' could not be found';
+const CONFIG_PROFILE_NOT_FOUND_MARKER = 'the config profile (';
+const CONFIG_PROFILE_NOT_FOUND_SUFFIX = ') could not be found';
 
 /**
  * Manager for AWS SSO credentials with automatic login on expiration
@@ -143,15 +144,13 @@ export class GOAWSCredentialsManager {
     }
 
     // Check for profile not found (not recoverable via login)
-    for (const pattern of PROFILE_NOT_FOUND_PATTERNS) {
-      if (pattern.test(message)) {
-        return {
-          type: GOAWSCredentialsErrorType.PROFILE_NOT_FOUND,
-          isRecoverable: false,
-          originalMessage: message,
-          profileName: this.extractProfileFromError(message),
-        };
-      }
+    if (this.isProfileNotFoundMessage(message)) {
+      return {
+        type: GOAWSCredentialsErrorType.PROFILE_NOT_FOUND,
+        isRecoverable: false,
+        originalMessage: message,
+        profileName: this.extractProfileFromError(message),
+      };
     }
 
     // Check for CredentialsProviderError (may be recoverable)
@@ -689,18 +688,119 @@ export class GOAWSCredentialsManager {
     return error.name === 'CredentialsProviderError' || error.constructor.name === 'CredentialsProviderError';
   }
 
+  private isProfileNotFoundMessage(message: string): boolean {
+    const lowerMessage = message.toLowerCase();
+    return this.hasProfileNotFoundMessage(lowerMessage) || this.hasConfigProfileNotFoundMessage(lowerMessage);
+  }
+
+  private hasProfileNotFoundMessage(lowerMessage: string): boolean {
+    let searchStart = 0;
+
+    while (searchStart < lowerMessage.length) {
+      const markerIndex = lowerMessage.indexOf(PROFILE_MARKER, searchStart);
+      if (markerIndex === -1) {
+        return false;
+      }
+
+      const profileStart = markerIndex + PROFILE_MARKER.length;
+      const suffixIndex = lowerMessage.indexOf(PROFILE_NOT_FOUND_SUFFIX, profileStart);
+      if (suffixIndex === -1) {
+        return false;
+      }
+      if (suffixIndex > profileStart) {
+        return true;
+      }
+
+      searchStart = profileStart + 1;
+    }
+
+    return false;
+  }
+
+  private hasConfigProfileNotFoundMessage(lowerMessage: string): boolean {
+    let searchStart = 0;
+
+    while (searchStart < lowerMessage.length) {
+      const markerIndex = lowerMessage.indexOf(CONFIG_PROFILE_NOT_FOUND_MARKER, searchStart);
+      if (markerIndex === -1) {
+        return false;
+      }
+
+      const profileStart = markerIndex + CONFIG_PROFILE_NOT_FOUND_MARKER.length;
+      const suffixIndex = lowerMessage.indexOf(CONFIG_PROFILE_NOT_FOUND_SUFFIX, profileStart);
+      if (suffixIndex === -1) {
+        return false;
+      }
+      if (suffixIndex > profileStart) {
+        return true;
+      }
+
+      searchStart = profileStart + 1;
+    }
+
+    return false;
+  }
+
   /**
    * Extract profile name from error message
    */
   private extractProfileFromError(message: string): string | undefined {
-    // Pattern: "profile 'name'" or "profile (name)"
-    const patterns = [/profile ['"]([^'"]+)['"]/i, /profile \(([^)]+)\)/i];
+    return this.extractQuotedProfileFromError(message) ?? this.extractParenthesizedProfileFromError(message);
+  }
 
-    for (const pattern of patterns) {
-      const match = pattern.exec(message);
-      if (match?.[1]) {
-        return match[1];
+  private extractQuotedProfileFromError(message: string): string | undefined {
+    return this.extractDelimitedProfileFromError(message, (opening) => {
+      switch (opening) {
+        case "'":
+        case '"':
+          return opening;
+        default:
+          return undefined;
       }
+    });
+  }
+
+  private extractParenthesizedProfileFromError(message: string): string | undefined {
+    return this.extractDelimitedProfileFromError(message, (opening) => (opening === '(' ? ')' : undefined));
+  }
+
+  private extractDelimitedProfileFromError(
+    message: string,
+    getClosingDelimiter: GOAWSProfileClosingDelimiterResolverFn,
+  ): string | undefined {
+    const lowerMessage = message.toLowerCase();
+    let searchStart = 0;
+
+    while (searchStart < message.length) {
+      const markerIndex = lowerMessage.indexOf(PROFILE_MARKER, searchStart);
+      if (markerIndex === -1) {
+        return undefined;
+      }
+
+      const openingIndex = markerIndex + PROFILE_MARKER.length;
+      const opening = message[openingIndex];
+      if (opening === undefined) {
+        return undefined;
+      }
+
+      const closing = getClosingDelimiter(opening);
+      if (closing === undefined) {
+        searchStart = openingIndex + 1;
+        continue;
+      }
+
+      const valueStart = openingIndex + 1;
+      const valueEnd = message.indexOf(closing, valueStart);
+      if (valueEnd === -1) {
+        return undefined;
+      }
+
+      const value = message.slice(valueStart, valueEnd);
+      if (value.length > 0) {
+        return value;
+      }
+
+      searchStart = valueEnd + 1;
     }
 
     return undefined;

--- a/packages/go-common/src/libs/aws/__tests__/GOAWSCredentialsManager.test.ts
+++ b/packages/go-common/src/libs/aws/__tests__/GOAWSCredentialsManager.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { GOAWSCredentialsErrorType } from '../GOAWSCredentialsError.js';
+import { GOAWSCredentialsManager } from '../GOAWSCredentialsManager.js';
+
+describe('GOAWSCredentialsManager', () => {
+  it('extracts quoted profile names from credential errors', () => {
+    const manager = new GOAWSCredentialsManager();
+    const singleQuoted = manager.analyzeError(
+      "The SSO session associated with this profile has expired for profile 'dev'",
+    );
+    const doubleQuoted = manager.analyzeError(
+      'The SSO session associated with this profile has expired for profile "prod"',
+    );
+
+    assert.strictEqual(singleQuoted.type, GOAWSCredentialsErrorType.SSO_SESSION_EXPIRED);
+    assert.strictEqual(singleQuoted.profileName, 'dev');
+    assert.strictEqual(doubleQuoted.type, GOAWSCredentialsErrorType.SSO_SESSION_EXPIRED);
+    assert.strictEqual(doubleQuoted.profileName, 'prod');
+  });
+
+  it('extracts parenthesized profile names from credential errors', () => {
+    const manager = new GOAWSCredentialsManager();
+    const analysis = manager.analyzeError('The config profile (prod) could not be found');
+
+    assert.strictEqual(analysis.type, GOAWSCredentialsErrorType.PROFILE_NOT_FOUND);
+    assert.strictEqual(analysis.profileName, 'prod');
+  });
+
+  it('detects simple profile-not-found messages without regex matching', () => {
+    const manager = new GOAWSCredentialsManager();
+    const analysis = manager.analyzeError('Profile dev could not be found');
+
+    assert.strictEqual(analysis.type, GOAWSCredentialsErrorType.PROFILE_NOT_FOUND);
+    assert.strictEqual(analysis.profileName, undefined);
+  });
+
+  it('prefers quoted profile names over parenthesized names to preserve legacy behavior', () => {
+    const manager = new GOAWSCredentialsManager();
+    const analysis = manager.analyzeError(
+      "The SSO session associated with this profile has expired for profile (ignored) and profile 'quoted'",
+    );
+
+    assert.strictEqual(analysis.type, GOAWSCredentialsErrorType.SSO_SESSION_EXPIRED);
+    assert.strictEqual(analysis.profileName, 'quoted');
+  });
+
+  it('handles malformed parenthesized profile messages without regex backtracking', () => {
+    const manager = new GOAWSCredentialsManager();
+    const analysis = manager.analyzeError(
+      `The SSO session associated with this profile has expired for profile (${'('.repeat(10_000)}`,
+    );
+
+    assert.strictEqual(analysis.type, GOAWSCredentialsErrorType.SSO_SESSION_EXPIRED);
+    assert.strictEqual(analysis.profileName, undefined);
+  });
+
+  it('handles malformed profile-not-found messages without regex backtracking', () => {
+    const manager = new GOAWSCredentialsManager();
+    const simpleAnalysis = manager.analyzeError(`Profile ${'profile '.repeat(10_000)}`);
+    const configAnalysis = manager.analyzeError(`The config profile (${'the config profile ('.repeat(10_000)}`);
+
+    assert.strictEqual(simpleAnalysis.type, GOAWSCredentialsErrorType.UNKNOWN);
+    assert.strictEqual(configAnalysis.type, GOAWSCredentialsErrorType.UNKNOWN);
+  });
+});

--- a/packages/go-common/src/libs/aws/__tests__/GOAWSCredentialsManager.test.ts
+++ b/packages/go-common/src/libs/aws/__tests__/GOAWSCredentialsManager.test.ts
@@ -46,6 +46,16 @@ describe('GOAWSCredentialsManager', () => {
     assert.strictEqual(analysis.profileName, 'quoted');
   });
 
+  it('continues scanning after a malformed delimited profile candidate', () => {
+    const manager = new GOAWSCredentialsManager();
+    const analysis = manager.analyzeError(
+      'The SSO session associated with this profile has expired for profile \'unterminated and profile "prod"',
+    );
+
+    assert.strictEqual(analysis.type, GOAWSCredentialsErrorType.SSO_SESSION_EXPIRED);
+    assert.strictEqual(analysis.profileName, 'prod');
+  });
+
   it('handles malformed parenthesized profile messages without regex backtracking', () => {
     const manager = new GOAWSCredentialsManager();
     const analysis = manager.analyzeError(

--- a/packages/go-common/src/libs/core/config/GOConfigObjectFlattener.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigObjectFlattener.ts
@@ -1,12 +1,14 @@
+import { formatUnsafeKeyLocation, isDangerousKey } from '../security/DangerousKeys.js';
 import { valueToString } from '../utils/GOValueToString.js';
 
 export type GOFlattenedConfigValue = string | string[];
 
 export interface GOConfigObjectFlattenerOptions {
   readonly rejectDangerousKeys?: boolean;
+  readonly maxDepth?: number;
 }
 
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const DEFAULT_MAX_DEPTH = 64;
 
 export class GOConfigObjectFlattener {
   static flatten(
@@ -18,12 +20,19 @@ export class GOConfigObjectFlattener {
   }
 
   private readonly rejectDangerousKeys: boolean;
+  private readonly maxDepth: number;
 
   private constructor(options: GOConfigObjectFlattenerOptions) {
     this.rejectDangerousKeys = options.rejectDangerousKeys ?? true;
+    this.maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+
+    if (!Number.isInteger(this.maxDepth) || this.maxDepth < 0) {
+      throw new Error('GOConfigObjectFlattener maxDepth must be a non-negative integer');
+    }
   }
 
-  private flattenObject(data: Record<string, unknown>, prefix = ''): Map<string, GOFlattenedConfigValue> {
+  private flattenObject(data: Record<string, unknown>, prefix = '', depth = 0): Map<string, GOFlattenedConfigValue> {
+    this.assertWithinDepth(prefix.length > 0 ? prefix : '(root)', depth);
     const result = new Map<string, GOFlattenedConfigValue>();
 
     for (const [key, value] of Object.entries(data)) {
@@ -35,9 +44,8 @@ export class GOConfigObjectFlattener {
         continue;
       }
 
-      this.assertSafeValue(value, fullKey);
-
       if (Array.isArray(value)) {
+        this.assertSafeValue(value, fullKey, depth + 1);
         result.set(
           fullKey,
           value.map((item) => valueToString(item)),
@@ -46,7 +54,7 @@ export class GOConfigObjectFlattener {
       }
 
       if (this.isFlattenableObject(value)) {
-        const nested = this.flattenObject(value, fullKey);
+        const nested = this.flattenObject(value, fullKey, depth + 1);
         for (const [nestedKey, nestedValue] of nested) {
           result.set(nestedKey, nestedValue);
         }
@@ -60,22 +68,24 @@ export class GOConfigObjectFlattener {
   }
 
   private assertSafeKey(key: string, prefix: string): void {
-    if (!this.rejectDangerousKeys || !DANGEROUS_KEYS.has(key)) {
+    if (!this.rejectDangerousKeys || !isDangerousKey(key)) {
       return;
     }
 
-    const location = prefix.length > 0 ? `${prefix}.${key}` : key;
+    const location = formatUnsafeKeyLocation(prefix, key);
     throw new Error(`Unsafe configuration key "${location}" is not allowed`);
   }
 
-  private assertSafeValue(value: unknown, location: string): void {
+  private assertSafeValue(value: unknown, location: string, depth: number): void {
+    this.assertWithinDepth(location, depth);
+
     if (!this.rejectDangerousKeys) {
       return;
     }
 
     if (Array.isArray(value)) {
       value.forEach((item, index) => {
-        this.assertSafeValue(item, `${location}[${String(index)}]`);
+        this.assertSafeValue(item, `${location}[${String(index)}]`, depth + 1);
       });
       return;
     }
@@ -85,10 +95,16 @@ export class GOConfigObjectFlattener {
     }
 
     for (const [key, nestedValue] of Object.entries(value)) {
-      if (DANGEROUS_KEYS.has(key)) {
+      if (isDangerousKey(key)) {
         throw new Error(`Unsafe configuration key "${location}.${key}" is not allowed`);
       }
-      this.assertSafeValue(nestedValue, `${location}.${key}`);
+      this.assertSafeValue(nestedValue, `${location}.${key}`, depth + 1);
+    }
+  }
+
+  private assertWithinDepth(location: string, depth: number): void {
+    if (depth > this.maxDepth) {
+      throw new Error(`Configuration object exceeds maximum depth of ${String(this.maxDepth)} at "${location}"`);
     }
   }
 

--- a/packages/go-common/src/libs/core/config/GOConfigObjectFlattener.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigObjectFlattener.ts
@@ -1,0 +1,102 @@
+import { valueToString } from '../utils/GOValueToString.js';
+
+export type GOFlattenedConfigValue = string | string[];
+
+export interface GOConfigObjectFlattenerOptions {
+  readonly rejectDangerousKeys?: boolean;
+}
+
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export class GOConfigObjectFlattener {
+  static flatten(
+    data: Record<string, unknown>,
+    options: GOConfigObjectFlattenerOptions = {},
+  ): Map<string, GOFlattenedConfigValue> {
+    const flattener = new GOConfigObjectFlattener(options);
+    return flattener.flattenObject(data);
+  }
+
+  private readonly rejectDangerousKeys: boolean;
+
+  private constructor(options: GOConfigObjectFlattenerOptions) {
+    this.rejectDangerousKeys = options.rejectDangerousKeys ?? true;
+  }
+
+  private flattenObject(data: Record<string, unknown>, prefix = ''): Map<string, GOFlattenedConfigValue> {
+    const result = new Map<string, GOFlattenedConfigValue>();
+
+    for (const [key, value] of Object.entries(data)) {
+      this.assertSafeKey(key, prefix);
+
+      const fullKey = prefix.length > 0 ? `${prefix}.${key}` : key;
+
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      this.assertSafeValue(value, fullKey);
+
+      if (Array.isArray(value)) {
+        result.set(
+          fullKey,
+          value.map((item) => valueToString(item)),
+        );
+        continue;
+      }
+
+      if (this.isFlattenableObject(value)) {
+        const nested = this.flattenObject(value, fullKey);
+        for (const [nestedKey, nestedValue] of nested) {
+          result.set(nestedKey, nestedValue);
+        }
+        continue;
+      }
+
+      result.set(fullKey, valueToString(value));
+    }
+
+    return result;
+  }
+
+  private assertSafeKey(key: string, prefix: string): void {
+    if (!this.rejectDangerousKeys || !DANGEROUS_KEYS.has(key)) {
+      return;
+    }
+
+    const location = prefix.length > 0 ? `${prefix}.${key}` : key;
+    throw new Error(`Unsafe configuration key "${location}" is not allowed`);
+  }
+
+  private assertSafeValue(value: unknown, location: string): void {
+    if (!this.rejectDangerousKeys) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => {
+        this.assertSafeValue(item, `${location}[${String(index)}]`);
+      });
+      return;
+    }
+
+    if (!this.isObjectLike(value) || Buffer.isBuffer(value) || value instanceof Date) {
+      return;
+    }
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (DANGEROUS_KEYS.has(key)) {
+        throw new Error(`Unsafe configuration key "${location}.${key}" is not allowed`);
+      }
+      this.assertSafeValue(nestedValue, `${location}.${key}`);
+    }
+  }
+
+  private isFlattenableObject(value: unknown): value is Record<string, unknown> {
+    return this.isObjectLike(value) && !Buffer.isBuffer(value) && !(value instanceof Date);
+  }
+
+  private isObjectLike(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+}

--- a/packages/go-common/src/libs/core/config/GOConfigParameter.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigParameter.ts
@@ -121,6 +121,16 @@ export interface GOConfigParameterOptions {
   sensitive?: boolean;
 
   /**
+   * Whether this parameter is reserved for framework-level usage.
+   *
+   * Reserved parameters are accepted by help/unknown-parameter detection and can
+   * be loaded internally, but they must not be exposed in application
+   * configuration DTOs returned by GOScript.getConfiguration<T>().
+   * Default: false
+   */
+  reserved?: boolean;
+
+  /**
    * Async fallback function called when value is not found in providers.
    * Executed AFTER checking defaultValue.
    * If both defaultValue and asyncFallback are set, defaultValue takes precedence.
@@ -167,6 +177,7 @@ export class GOConfigParameter {
   readonly deprecated: boolean;
   readonly deprecationMessage?: string | undefined;
   readonly sensitive: boolean;
+  readonly reserved: boolean;
   readonly asyncFallback?: GOConfigParameterFallbackFn | undefined;
 
   constructor(options: GOConfigParameterOptions) {
@@ -187,6 +198,7 @@ export class GOConfigParameter {
     this.deprecated = options.deprecated ?? false;
     this.deprecationMessage = options.deprecationMessage;
     this.sensitive = options.sensitive ?? false;
+    this.reserved = options.reserved ?? false;
     this.asyncFallback = options.asyncFallback;
   }
 

--- a/packages/go-common/src/libs/core/config/GOConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigProvider.ts
@@ -10,6 +10,15 @@
  */
 export interface GOConfigProvider {
   /**
+   * Prepare provider values before a configuration load.
+   *
+   * Providers with static values can omit this method. Dynamic providers can
+   * use it to refresh their internal values while keeping the provider chain
+   * itself immutable.
+   */
+  prepare?(): void | Promise<void>;
+
+  /**
    * Get raw value for a configuration key
    * @param key - Configuration key (e.g., "http.timeout")
    * @returns String value, array of strings, or undefined if not found

--- a/packages/go-common/src/libs/core/config/GOConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigProvider.ts
@@ -63,7 +63,7 @@ export interface GOConfigProvider {
  * Abstract base class for configuration providers
  */
 export abstract class GOConfigProviderBase implements GOConfigProvider {
-  protected abstract values: Map<string, string | string[]>;
+  protected abstract readonly values: Map<string, string | string[]>;
 
   abstract getName(): string;
   abstract isSecret(key: string): boolean;

--- a/packages/go-common/src/libs/core/config/GOConfigReader.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigReader.ts
@@ -58,6 +58,19 @@ export class GOConfigReader {
   }
 
   /**
+   * Prepare providers for a new configuration load.
+   * The provider chain remains immutable; only provider-owned dynamic state is
+   * refreshed. Access tracking is per load, so it is cleared here.
+   */
+  async prepareProviders(): Promise<void> {
+    this.accessLog.clear();
+
+    for (const provider of this.providers) {
+      await provider.prepare?.();
+    }
+  }
+
+  /**
    * Get string value
    * @param forKey - Configuration key
    * @param defaultValue - Default value if key not found

--- a/packages/go-common/src/libs/core/config/GOConfigSchema.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigSchema.ts
@@ -59,6 +59,22 @@ export class GOConfigSchema {
   }
 
   /**
+   * Add framework-level reserved parameters.
+   *
+   * Reserved parameters participate in help generation and unknown-parameter
+   * detection, but callers such as GOScript.getConfiguration<T>() can filter
+   * them out of application configuration DTOs.
+   */
+  addReservedParameters(parameterOptions: ReadonlyArray<GOConfigParameterOptions>): void {
+    for (const options of parameterOptions) {
+      if (this.parameters.has(options.name)) {
+        throw new Error(`Reserved parameter "${options.name}" conflicts with an existing script parameter`);
+      }
+      this.addParameter({ ...options, reserved: true });
+    }
+  }
+
+  /**
    * Get a parameter by name
    */
   getParameter(name: string): GOConfigParameter | undefined {
@@ -239,6 +255,7 @@ export class GOConfigSchema {
         aliases: p.aliases,
         deprecated: p.deprecated,
         sensitive: p.sensitive,
+        reserved: p.reserved,
       })),
     };
   }

--- a/packages/go-common/src/libs/core/config/GOConfigSchema.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigSchema.ts
@@ -13,6 +13,14 @@ import type { GOConfigHelpGeneratorOptions } from './GOConfigHelpGenerator.js';
 import { getErrorMessage } from '../errors/GOErrorUtils.js';
 import { valueToString } from '../utils/GOValueToString.js';
 
+type GOConfigSchemaIdentifierKind = 'name' | 'alias' | 'cliFlag';
+
+interface GOConfigSchemaIdentifierOwner {
+  readonly parameterName: string;
+  readonly kind: GOConfigSchemaIdentifierKind;
+  readonly reserved: boolean;
+}
+
 /**
  * Configuration schema options
  */
@@ -66,12 +74,135 @@ export class GOConfigSchema {
    * them out of application configuration DTOs.
    */
   addReservedParameters(parameterOptions: ReadonlyArray<GOConfigParameterOptions>): void {
-    for (const options of parameterOptions) {
-      if (this.parameters.has(options.name)) {
-        throw new Error(`Reserved parameter "${options.name}" conflicts with an existing script parameter`);
-      }
-      this.addParameter({ ...options, reserved: true });
+    const reservedParameters = parameterOptions.map((options) => new GOConfigParameter({ ...options, reserved: true }));
+    this.validateReservedParameterConflicts(reservedParameters);
+
+    for (const parameter of reservedParameters) {
+      this.parameters.set(parameter.name, parameter);
     }
+  }
+
+  private validateReservedParameterConflicts(reservedParameters: ReadonlyArray<GOConfigParameter>): void {
+    const configIdentifiers = new Map<string, GOConfigSchemaIdentifierOwner>();
+    const cliIdentifiers = new Map<string, GOConfigSchemaIdentifierOwner>();
+
+    for (const parameter of this.parameters.values()) {
+      this.registerParameterIdentifiers(configIdentifiers, cliIdentifiers, parameter, false);
+    }
+
+    for (const parameter of reservedParameters) {
+      this.registerParameterIdentifiers(configIdentifiers, cliIdentifiers, parameter, true);
+    }
+  }
+
+  private registerParameterIdentifiers(
+    configIdentifiers: Map<string, GOConfigSchemaIdentifierOwner>,
+    cliIdentifiers: Map<string, GOConfigSchemaIdentifierOwner>,
+    parameter: GOConfigParameter,
+    failOnConflict: boolean,
+  ): void {
+    const reserved = parameter.reserved;
+
+    this.registerIdentifier(
+      configIdentifiers,
+      parameter.name,
+      {
+        parameterName: parameter.name,
+        kind: 'name',
+        reserved,
+      },
+      failOnConflict,
+    );
+
+    for (const alias of parameter.aliases) {
+      this.registerIdentifier(
+        configIdentifiers,
+        alias,
+        {
+          parameterName: parameter.name,
+          kind: 'alias',
+          reserved,
+        },
+        failOnConflict,
+      );
+    }
+
+    this.registerIdentifier(
+      cliIdentifiers,
+      this.normalizeCliIdentifier(parameter.cliFlag),
+      {
+        parameterName: parameter.name,
+        kind: 'cliFlag',
+        reserved,
+      },
+      failOnConflict,
+    );
+
+    for (const alias of parameter.aliases) {
+      this.registerIdentifier(
+        cliIdentifiers,
+        this.normalizeCliIdentifier(alias),
+        {
+          parameterName: parameter.name,
+          kind: 'alias',
+          reserved,
+        },
+        failOnConflict,
+      );
+    }
+  }
+
+  private registerIdentifier(
+    identifiers: Map<string, GOConfigSchemaIdentifierOwner>,
+    identifier: string,
+    owner: GOConfigSchemaIdentifierOwner,
+    failOnConflict: boolean,
+  ): void {
+    const existing = identifiers.get(identifier);
+    if (existing === undefined) {
+      identifiers.set(identifier, owner);
+      return;
+    }
+
+    if (failOnConflict) {
+      throw new Error(this.formatReservedParameterConflictError(identifier, owner, existing));
+    }
+  }
+
+  private formatReservedParameterConflictError(
+    identifier: string,
+    reservedOwner: GOConfigSchemaIdentifierOwner,
+    existingOwner: GOConfigSchemaIdentifierOwner,
+  ): string {
+    if (reservedOwner.kind === 'name' && existingOwner.kind === 'name' && !existingOwner.reserved) {
+      return `Reserved parameter "${reservedOwner.parameterName}" conflicts with an existing script parameter`;
+    }
+
+    const existingType = existingOwner.reserved ? 'reserved parameter' : 'existing script parameter';
+    return `Reserved parameter "${reservedOwner.parameterName}" ${this.formatIdentifierOwner(
+      reservedOwner,
+      identifier,
+    )} conflicts with ${existingType} "${existingOwner.parameterName}" ${this.formatIdentifierOwner(
+      existingOwner,
+      identifier,
+    )}`;
+  }
+
+  private formatIdentifierOwner(owner: GOConfigSchemaIdentifierOwner, identifier: string): string {
+    switch (owner.kind) {
+      case 'name':
+        return `name "${identifier}"`;
+      case 'alias':
+        return `alias "${identifier}"`;
+      case 'cliFlag':
+        return `CLI flag "${identifier}"`;
+      default:
+        return `identifier "${identifier}"`;
+    }
+  }
+
+  private normalizeCliIdentifier(identifier: string): string {
+    return identifier.trim().replace(/^--?/, '');
   }
 
   /**

--- a/packages/go-common/src/libs/core/config/GOConfigTypeConverter.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigTypeConverter.ts
@@ -6,6 +6,7 @@
  */
 
 import { getErrorMessage } from '../errors/GOErrorUtils.js';
+import { valueToString } from '../utils/GOValueToString.js';
 
 type GOConfigValueTransformer<T> = (value: string | string[]) => T;
 
@@ -16,10 +17,21 @@ export class GOConfigTypeConverter {
   /**
    * Convert to string
    * @param value - Raw value from provider
-   * @returns String value (first element if array)
+   * @returns String value
+   * @throws Error if multiple values are supplied for a scalar string
    */
   static toString(value: string | string[]): string {
-    return Array.isArray(value) ? (value[0] ?? '') : value;
+    if (!Array.isArray(value)) {
+      return value;
+    }
+
+    if (value.length <= 1) {
+      return value[0] ?? '';
+    }
+
+    throw new Error(
+      `Cannot convert multiple values to string: ${valueToString(value)}. Use a string array parameter instead.`,
+    );
   }
 
   /**

--- a/packages/go-common/src/libs/core/config/GOConfigTypeConverter.ts
+++ b/packages/go-common/src/libs/core/config/GOConfigTypeConverter.ts
@@ -6,7 +6,6 @@
  */
 
 import { getErrorMessage } from '../errors/GOErrorUtils.js';
-import { valueToString } from '../utils/GOValueToString.js';
 
 type GOConfigValueTransformer<T> = (value: string | string[]) => T;
 
@@ -30,7 +29,7 @@ export class GOConfigTypeConverter {
     }
 
     throw new Error(
-      `Cannot convert multiple values to string: ${valueToString(value)}. Use a string array parameter instead.`,
+      `Cannot convert ${value.length.toString()} values to string. Use a string array parameter instead.`,
     );
   }
 

--- a/packages/go-common/src/libs/core/config/__tests__/GOConfigObjectFlattener.test.ts
+++ b/packages/go-common/src/libs/core/config/__tests__/GOConfigObjectFlattener.test.ts
@@ -3,6 +3,20 @@ import { describe, it } from 'node:test';
 
 import { GOConfigObjectFlattener } from '../GOConfigObjectFlattener.js';
 
+function createNestedObject(depth: number): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let cursor = root;
+
+  for (let index = 0; index < depth; index++) {
+    const next: Record<string, unknown> = {};
+    cursor[`level${String(index)}`] = next;
+    cursor = next;
+  }
+
+  cursor['value'] = 'ok';
+  return root;
+}
+
 describe('GOConfigObjectFlattener', () => {
   it('flattens nested objects and converts primitive values to strings', () => {
     const flattened = GOConfigObjectFlattener.flatten({
@@ -43,6 +57,13 @@ describe('GOConfigObjectFlattener', () => {
           entries: [{ prototype: 'bad' }],
         }),
       /Unsafe configuration key "entries\[0\]\.prototype" is not allowed/,
+    );
+  });
+
+  it('rejects objects deeper than the configured max depth', () => {
+    assert.throws(
+      () => GOConfigObjectFlattener.flatten(createNestedObject(3), { maxDepth: 2 }),
+      /Configuration object exceeds maximum depth of 2/,
     );
   });
 });

--- a/packages/go-common/src/libs/core/config/__tests__/GOConfigObjectFlattener.test.ts
+++ b/packages/go-common/src/libs/core/config/__tests__/GOConfigObjectFlattener.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { GOConfigObjectFlattener } from '../GOConfigObjectFlattener.js';
+
+describe('GOConfigObjectFlattener', () => {
+  it('flattens nested objects and converts primitive values to strings', () => {
+    const flattened = GOConfigObjectFlattener.flatten({
+      athena: {
+        database: 'pn_analytics',
+        max: {
+          attempts: 60,
+        },
+      },
+      flags: ['a', 2, true],
+      enabled: true,
+      empty: null,
+    });
+
+    assert.strictEqual(flattened.get('athena.database'), 'pn_analytics');
+    assert.strictEqual(flattened.get('athena.max.attempts'), '60');
+    assert.deepStrictEqual(flattened.get('flags'), ['a', '2', 'true']);
+    assert.strictEqual(flattened.get('enabled'), 'true');
+    assert.strictEqual(flattened.has('empty'), false);
+  });
+
+  it('rejects dangerous keys at nested levels', () => {
+    assert.throws(
+      () =>
+        GOConfigObjectFlattener.flatten({
+          safe: {
+            constructor: 'bad',
+          },
+        }),
+      /Unsafe configuration key "safe\.constructor" is not allowed/,
+    );
+  });
+
+  it('rejects dangerous keys inside array objects', () => {
+    assert.throws(
+      () =>
+        GOConfigObjectFlattener.flatten({
+          entries: [{ prototype: 'bad' }],
+        }),
+      /Unsafe configuration key "entries\[0\]\.prototype" is not allowed/,
+    );
+  });
+});

--- a/packages/go-common/src/libs/core/config/__tests__/GOConfigTypeConverter.test.ts
+++ b/packages/go-common/src/libs/core/config/__tests__/GOConfigTypeConverter.test.ts
@@ -14,10 +14,21 @@ describe('GOConfigTypeConverter', () => {
     assert.strictEqual(GOConfigTypeConverter.toBool('yes'), true);
     assert.strictEqual(GOConfigTypeConverter.toBool('off'), false);
 
-    assert.throws(() => GOConfigTypeConverter.toString(['first', 'second']), /multiple values/);
+    assert.throws(() => GOConfigTypeConverter.toString(['first', 'second']), /Cannot convert 2 values to string/);
     assert.throws(() => GOConfigTypeConverter.toInt('not-a-number'), /Cannot convert/);
     assert.throws(() => GOConfigTypeConverter.toDouble('not-a-number'), /Cannot convert/);
     assert.throws(() => GOConfigTypeConverter.toBool('maybe'), /Cannot convert/);
+  });
+
+  it('does not include raw multiple string values in conversion errors', () => {
+    assert.throws(
+      () => GOConfigTypeConverter.toString(['secret-token-1', 'secret-token-2']),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes('Cannot convert 2 values to string') &&
+        !error.message.includes('secret-token-1') &&
+        !error.message.includes('secret-token-2'),
+    );
   });
 
   it('converts array configuration values', () => {

--- a/packages/go-common/src/libs/core/config/__tests__/GOConfigTypeConverter.test.ts
+++ b/packages/go-common/src/libs/core/config/__tests__/GOConfigTypeConverter.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { GOConfigParameterType, getTypePlaceholder } from '../GOConfigParameterType.js';
+import { GOConfigTypeConverter } from '../GOConfigTypeConverter.js';
+import { GOSecretRedactor, GOSecretsSpecifierFactory } from '../GOSecretsSpecifier.js';
+
+describe('GOConfigTypeConverter', () => {
+  it('converts scalar configuration values', () => {
+    assert.strictEqual(GOConfigTypeConverter.toString(['first']), 'first');
+    assert.strictEqual(GOConfigTypeConverter.toString([]), '');
+    assert.strictEqual(GOConfigTypeConverter.toInt('42'), 42);
+    assert.strictEqual(GOConfigTypeConverter.toDouble('3.5'), 3.5);
+    assert.strictEqual(GOConfigTypeConverter.toBool('yes'), true);
+    assert.strictEqual(GOConfigTypeConverter.toBool('off'), false);
+
+    assert.throws(() => GOConfigTypeConverter.toString(['first', 'second']), /multiple values/);
+    assert.throws(() => GOConfigTypeConverter.toInt('not-a-number'), /Cannot convert/);
+    assert.throws(() => GOConfigTypeConverter.toDouble('not-a-number'), /Cannot convert/);
+    assert.throws(() => GOConfigTypeConverter.toBool('maybe'), /Cannot convert/);
+  });
+
+  it('converts array configuration values', () => {
+    assert.deepStrictEqual(GOConfigTypeConverter.toStringArray(' a, b ,, c '), ['a', 'b', 'c']);
+    assert.deepStrictEqual(GOConfigTypeConverter.toStringArray(['x', 'y']), ['x', 'y']);
+    assert.deepStrictEqual(GOConfigTypeConverter.toStringArray(''), []);
+    assert.deepStrictEqual(GOConfigTypeConverter.toIntArray('1, 2'), [1, 2]);
+    assert.deepStrictEqual(GOConfigTypeConverter.toDoubleArray('1.5, 2.25'), [1.5, 2.25]);
+    assert.deepStrictEqual(GOConfigTypeConverter.toBoolArray('true,false,on'), [true, false, true]);
+
+    assert.throws(() => GOConfigTypeConverter.toIntArray('1,x'), /Cannot convert/);
+    assert.throws(() => GOConfigTypeConverter.toDoubleArray('1,x'), /Cannot convert/);
+  });
+
+  it('converts buffer values and supports safe fallback conversion', () => {
+    const encoded = Buffer.from('hello', 'utf8').toString('base64');
+
+    assert.strictEqual(GOConfigTypeConverter.toBuffer(encoded).toString('utf8'), 'hello');
+    assert.deepStrictEqual(
+      GOConfigTypeConverter.toBufferArray(`${encoded},${encoded}`).map((buffer) => buffer.toString('utf8')),
+      ['hello', 'hello'],
+    );
+    assert.strictEqual(
+      GOConfigTypeConverter.tryConvert(GOConfigTypeConverter.toInt.bind(GOConfigTypeConverter), '8', 7),
+      8,
+    );
+    assert.strictEqual(
+      GOConfigTypeConverter.tryConvert(GOConfigTypeConverter.toInt.bind(GOConfigTypeConverter), 'bad', 7),
+      7,
+    );
+    assert.strictEqual(
+      GOConfigTypeConverter.tryConvert(GOConfigTypeConverter.toInt.bind(GOConfigTypeConverter), undefined, 7),
+      7,
+    );
+  });
+});
+
+describe('GOConfigParameterType', () => {
+  it('returns display placeholders for known and unknown parameter types', () => {
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.STRING), '<value>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.INT), '<number>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.DOUBLE), '<decimal>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.BOOL), '');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.STRING_ARRAY), '<value1,value2,...>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.INT_ARRAY), '<num1,num2,...>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.DOUBLE_ARRAY), '<dec1,dec2,...>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.BOOL_ARRAY), '<true,false,...>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.BUFFER), '<base64>');
+    assert.strictEqual(getTypePlaceholder(GOConfigParameterType.BUFFER_ARRAY), '<base64,base64,...>');
+    assert.strictEqual(getTypePlaceholder('unknown' as GOConfigParameterType), '<value>');
+  });
+});
+
+describe('GOSecretRedactor', () => {
+  it('supports all secret specifier modes and redacts scalar and array values', () => {
+    const allRedactor = new GOSecretRedactor(GOSecretsSpecifierFactory.all());
+    const dynamicRedactor = new GOSecretRedactor(
+      GOSecretsSpecifierFactory.dynamic(
+        (key, value) => key === 'secret' && GOConfigTypeConverter.toString(value) !== '',
+      ),
+    );
+
+    assert.strictEqual(new GOSecretRedactor().isSecret('token', 'value'), false);
+    assert.strictEqual(allRedactor.isSecret('anything', 'value'), true);
+    assert.strictEqual(
+      new GOSecretRedactor(GOSecretsSpecifierFactory.specific(['token'])).isSecret('token', 'x'),
+      true,
+    );
+    assert.strictEqual(dynamicRedactor.isSecret('secret', 'x'), true);
+    assert.strictEqual(allRedactor.redact('abcdef'), '[REDACTED (6 chars)]');
+    assert.strictEqual(allRedactor.redact(['a', 'b']), '[REDACTED (2 items)]');
+  });
+});

--- a/packages/go-common/src/libs/core/config/index.ts
+++ b/packages/go-common/src/libs/core/config/index.ts
@@ -10,6 +10,7 @@ export * from './GOConfigProvider.js';
 export * from './GOConfigReader.js';
 export * from './GOConfigKeyTransformer.js';
 export * from './GOConfigTypeConverter.js';
+export * from './GOConfigObjectFlattener.js';
 export * from './GOSecretsSpecifier.js';
 
 // Schema & Parameters
@@ -25,6 +26,7 @@ export * from './providers/GOYAMLConfigProvider.js';
 export * from './providers/GOEnvironmentConfigProvider.js';
 export * from './providers/GOCommandLineConfigProvider.js';
 export * from './providers/GOLambdaEventConfigProvider.js';
+export * from './providers/GOPresetConfigProvider.js';
 
 // Parsers
 export * from './parsers/GOEnvFileParser.js';

--- a/packages/go-common/src/libs/core/config/parsers/GOYAMLParser.ts
+++ b/packages/go-common/src/libs/core/config/parsers/GOYAMLParser.ts
@@ -108,7 +108,7 @@ export class GOYAMLParser {
       const sourceValue = source[key];
       const targetValue = target[key];
 
-      if (isYAMLObject(sourceValue) && isYAMLObject(targetValue)) {
+      if (Object.prototype.hasOwnProperty.call(target, key) && isYAMLObject(sourceValue) && isYAMLObject(targetValue)) {
         // Recursively merge nested objects
         this.deepMerge(targetValue, sourceValue);
       } else {

--- a/packages/go-common/src/libs/core/config/parsers/GOYAMLParser.ts
+++ b/packages/go-common/src/libs/core/config/parsers/GOYAMLParser.ts
@@ -9,6 +9,12 @@ import * as fs from 'fs';
 import * as YAML from 'yaml';
 import { getErrorMessage } from '../../errors/GOErrorUtils.js';
 
+const SAFE_YAML_PARSE_OPTIONS: YAML.ParseOptions & YAML.DocumentOptions & YAML.SchemaOptions = {
+  logLevel: 'error',
+  schema: 'core',
+  uniqueKeys: true,
+};
+
 /**
  * Represents a YAML value which can be a primitive, array, or nested object.
  * Used for type-safe handling of parsed YAML content.
@@ -61,7 +67,7 @@ export class GOYAMLParser {
    */
   static parseContent(content: string): YAMLValue {
     try {
-      return YAML.parse(content) as YAMLValue;
+      return YAML.parse(content, SAFE_YAML_PARSE_OPTIONS) as YAMLValue;
     } catch (error: unknown) {
       throw new Error(`Failed to parse YAML content: ${getErrorMessage(error)}`, { cause: error });
     }

--- a/packages/go-common/src/libs/core/config/parsers/GOYAMLParser.ts
+++ b/packages/go-common/src/libs/core/config/parsers/GOYAMLParser.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as YAML from 'yaml';
 import { getErrorMessage } from '../../errors/GOErrorUtils.js';
+import { isDangerousKey } from '../../security/DangerousKeys.js';
 
 const SAFE_YAML_PARSE_OPTIONS: YAML.ParseOptions & YAML.DocumentOptions & YAML.SchemaOptions = {
   logLevel: 'error',
@@ -100,7 +101,7 @@ export class GOYAMLParser {
    */
   private static deepMerge(target: Record<string, YAMLValue>, source: Record<string, YAMLValue>): void {
     for (const key of Object.keys(source)) {
-      if (key === '__proto__' || key === 'constructor') {
+      if (isDangerousKey(key)) {
         continue;
       }
 
@@ -112,9 +113,28 @@ export class GOYAMLParser {
         this.deepMerge(targetValue, sourceValue);
       } else {
         // Overwrite with source value
-        target[key] = sourceValue;
+        target[key] = this.sanitizeMergedValue(sourceValue);
       }
     }
+  }
+
+  private static sanitizeMergedValue(value: YAMLValue): YAMLValue {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sanitizeMergedValue(item));
+    }
+
+    if (!isYAMLObject(value)) {
+      return value;
+    }
+
+    const sanitized: Record<string, YAMLValue> = {};
+    for (const key of Object.keys(value)) {
+      if (isDangerousKey(key)) {
+        continue;
+      }
+      sanitized[key] = this.sanitizeMergedValue(value[key]);
+    }
+    return sanitized;
   }
 
   /**

--- a/packages/go-common/src/libs/core/config/parsers/__tests__/GOYAMLParser.test.ts
+++ b/packages/go-common/src/libs/core/config/parsers/__tests__/GOYAMLParser.test.ts
@@ -57,7 +57,14 @@ describe('GOYAMLParser', () => {
     );
     const overrideFile = writeTempYamlFile(
       'override.yaml',
-      ['safe:', '  value: override', '  __proto__: blocked', 'prototype: blocked'].join('\n'),
+      [
+        'safe:',
+        '  value: override',
+        '  __proto__: blocked',
+        'prototype: blocked',
+        'toString:',
+        '  value: own-value',
+      ].join('\n'),
     );
 
     const merged = GOYAMLParser.parseFiles([baseFile, overrideFile]);
@@ -68,8 +75,12 @@ describe('GOYAMLParser', () => {
         nested: 'keep',
         items: [{ name: 'ok' }],
       },
+      toString: {
+        value: 'own-value',
+      },
     });
     assert.strictEqual(Object.prototype.hasOwnProperty.call(merged, 'constructor'), false);
     assert.strictEqual(Object.prototype.hasOwnProperty.call(merged, 'prototype'), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(merged, 'toString'), true);
   });
 });

--- a/packages/go-common/src/libs/core/config/parsers/__tests__/GOYAMLParser.test.ts
+++ b/packages/go-common/src/libs/core/config/parsers/__tests__/GOYAMLParser.test.ts
@@ -1,7 +1,27 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach } from 'node:test';
 import { describe, it } from 'node:test';
 
 import { GOYAMLParser, isYAMLObject } from '../GOYAMLParser.js';
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeTempYamlFile(fileName: string, content: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'go-yaml-parser-'));
+  tempRoots.push(root);
+  const filePath = path.join(root, fileName);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
 
 describe('GOYAMLParser', () => {
   it('does not materialize unsafe JavaScript YAML tags', () => {
@@ -18,5 +38,38 @@ describe('GOYAMLParser', () => {
 
   it('rejects duplicate mapping keys', () => {
     assert.throws(() => GOYAMLParser.parseContent(['a: 1', 'a: 2'].join('\n')), /Map keys must be unique/);
+  });
+
+  it('skips dangerous keys while merging YAML files', () => {
+    const baseFile = writeTempYamlFile(
+      'base.yaml',
+      [
+        'safe:',
+        '  value: base',
+        '  nested: keep',
+        '  prototype: blocked',
+        '  items:',
+        '    - name: ok',
+        '      constructor: blocked',
+        'constructor: blocked',
+        '__proto__: blocked',
+      ].join('\n'),
+    );
+    const overrideFile = writeTempYamlFile(
+      'override.yaml',
+      ['safe:', '  value: override', '  __proto__: blocked', 'prototype: blocked'].join('\n'),
+    );
+
+    const merged = GOYAMLParser.parseFiles([baseFile, overrideFile]);
+
+    assert.deepStrictEqual(merged, {
+      safe: {
+        value: 'override',
+        nested: 'keep',
+        items: [{ name: 'ok' }],
+      },
+    });
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(merged, 'constructor'), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(merged, 'prototype'), false);
   });
 });

--- a/packages/go-common/src/libs/core/config/parsers/__tests__/GOYAMLParser.test.ts
+++ b/packages/go-common/src/libs/core/config/parsers/__tests__/GOYAMLParser.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { GOYAMLParser, isYAMLObject } from '../GOYAMLParser.js';
+
+describe('GOYAMLParser', () => {
+  it('does not materialize unsafe JavaScript YAML tags', () => {
+    const parsed = GOYAMLParser.parseContent(
+      ['fn: !!js/function >', '  function () { return 1; }', 're: !!js/regexp /abc/g'].join('\n'),
+    );
+
+    assert.ok(isYAMLObject(parsed));
+    assert.strictEqual(typeof parsed['fn'], 'string');
+    assert.strictEqual(typeof parsed['re'], 'string');
+    assert.ok(!(parsed['fn'] instanceof Function));
+    assert.ok(!(parsed['re'] instanceof RegExp));
+  });
+
+  it('rejects duplicate mapping keys', () => {
+    assert.throws(() => GOYAMLParser.parseContent(['a: 1', 'a: 2'].join('\n')), /Map keys must be unique/);
+  });
+});

--- a/packages/go-common/src/libs/core/config/providers/GOCommandLineConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOCommandLineConfigProvider.ts
@@ -38,7 +38,7 @@ export interface GOCommandLineConfigProviderOptions {
  * Command line configuration provider
  */
 export class GOCommandLineConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]>;
+  protected readonly values: Map<string, string | string[]>;
   private readonly secretRedactor: GOSecretRedactor;
   private readonly rawArgs: string[];
 

--- a/packages/go-common/src/libs/core/config/providers/GOEnvironmentConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOEnvironmentConfigProvider.ts
@@ -45,7 +45,7 @@ export interface GOEnvironmentConfigProviderOptions {
  * Environment configuration provider
  */
 export class GOEnvironmentConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]>;
+  protected readonly values: Map<string, string | string[]>;
   private readonly secretRedactor: GOSecretRedactor;
   private readonly envFilePath?: string | undefined;
   private readonly arraySeparator: string;

--- a/packages/go-common/src/libs/core/config/providers/GOInMemoryConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOInMemoryConfigProvider.ts
@@ -29,7 +29,7 @@ export interface GOInMemoryConfigProviderOptions {
  * In-memory configuration provider
  */
 export class GOInMemoryConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]>;
+  protected readonly values: Map<string, string | string[]>;
   private readonly secretRedactor: GOSecretRedactor;
   private readonly providerName: string;
 

--- a/packages/go-common/src/libs/core/config/providers/GOJSONConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOJSONConfigProvider.ts
@@ -40,7 +40,7 @@ export interface GOJSONConfigProviderOptions {
  * JSON configuration provider
  */
 export class GOJSONConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]>;
+  protected readonly values: Map<string, string | string[]>;
   private readonly secretRedactor: GOSecretRedactor;
   private readonly filePath?: string | undefined;
   private readonly isOptional: boolean;

--- a/packages/go-common/src/libs/core/config/providers/GOJSONConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOJSONConfigProvider.ts
@@ -8,9 +8,9 @@
 import * as fs from 'fs';
 
 import { GOConfigProviderBase } from '../GOConfigProvider.js';
+import { GOConfigObjectFlattener } from '../GOConfigObjectFlattener.js';
 import { GOSecretRedactor, GOSecretsSpecifierFactory } from '../GOSecretsSpecifier.js';
 import type { GOSecretsSpecifier } from '../GOSecretsSpecifier.js';
-import { valueToString } from '../../utils/GOValueToString.js';
 import { getErrorMessage } from '../../errors/GOErrorUtils.js';
 
 /**
@@ -103,48 +103,10 @@ export class GOJSONConfigProvider extends GOConfigProviderBase {
    * Load configuration from JSON object
    */
   private loadFromData(data: Record<string, unknown>): void {
-    const flattened = this.flattenObject(data);
+    const flattened = GOConfigObjectFlattener.flatten(data);
     for (const [key, value] of flattened) {
       this.values.set(key, value);
     }
-  }
-
-  /**
-   * Flatten nested object into dot-notation keys
-   *
-   * @example
-   * { http: { client: { timeout: 60 } } } -> { "http.client.timeout": "60" }
-   */
-  private flattenObject(obj: Record<string, unknown>, prefix = ''): Map<string, string | string[]> {
-    const result = new Map<string, string | string[]>();
-
-    for (const [key, value] of Object.entries(obj)) {
-      const fullKey = prefix ? `${prefix}.${key}` : key;
-
-      if (value === null || value === undefined) {
-        // Skip null/undefined values
-        continue;
-      }
-
-      if (Array.isArray(value)) {
-        // Handle arrays - convert all elements to strings
-        result.set(
-          fullKey,
-          value.map((v: unknown) => valueToString(v)),
-        );
-      } else if (typeof value === 'object' && !Buffer.isBuffer(value)) {
-        // Recursively flatten nested objects
-        const nested = this.flattenObject(value as Record<string, unknown>, fullKey);
-        for (const [nestedKey, nestedValue] of nested) {
-          result.set(nestedKey, nestedValue);
-        }
-      } else {
-        // Primitive values
-        result.set(fullKey, valueToString(value));
-      }
-    }
-
-    return result;
   }
 
   /**

--- a/packages/go-common/src/libs/core/config/providers/GOLambdaEventConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOLambdaEventConfigProvider.ts
@@ -41,7 +41,7 @@ const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
  * expected by the GOScript configuration system.
  */
 export class GOLambdaEventConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]>;
+  protected readonly values: Map<string, string | string[]>;
   private readonly secretRedactor: GOSecretRedactor;
 
   constructor(event: Record<string, unknown>) {

--- a/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
@@ -1,0 +1,161 @@
+import { GOConfigProviderBase } from '../GOConfigProvider.js';
+import type { GOConfigProvider } from '../GOConfigProvider.js';
+import type { GOConfigSchema } from '../GOConfigSchema.js';
+import { GOConfigTypeConverter } from '../GOConfigTypeConverter.js';
+import { GOSecretRedactor, GOSecretsSpecifierFactory } from '../GOSecretsSpecifier.js';
+import type { GOSecretsSpecifier } from '../GOSecretsSpecifier.js';
+
+export interface GOPresetConfigProviderSelection {
+  readonly presetName: string;
+  readonly presetFile?: string;
+}
+
+export interface GOPresetConfigProviderResolution {
+  readonly name: string;
+  readonly sourcePath: string;
+  readonly sourceDisplayPath: string;
+  readonly values: ReadonlyMap<string, string | string[]>;
+  readonly unknownKeys: ReadonlyArray<string>;
+  readonly allowUnknownKeys: boolean;
+}
+
+type GOPresetConfigLoaderFn = (selection: GOPresetConfigProviderSelection) => GOPresetConfigProviderResolution;
+type GOPresetConfigLogHandler = (message: string) => void;
+
+export interface GOPresetConfigProviderOptions {
+  readonly selectorProviders: ReadonlyArray<GOConfigProvider>;
+  readonly presetNameParameter: string;
+  readonly presetFileParameter: string;
+  readonly schema: GOConfigSchema;
+  readonly loadPreset: GOPresetConfigLoaderFn;
+  readonly secretsSpecifier?: GOSecretsSpecifier;
+  readonly onInfo?: GOPresetConfigLogHandler;
+  readonly onWarning?: GOPresetConfigLogHandler;
+}
+
+export class GOPresetConfigProvider extends GOConfigProviderBase {
+  protected values: Map<string, string | string[]> = new Map();
+  private readonly secretRedactor: GOSecretRedactor;
+  private readonly selectorProviders: ReadonlyArray<GOConfigProvider>;
+  private readonly presetNameParameter: string;
+  private readonly presetFileParameter: string;
+  private readonly schema: GOConfigSchema;
+  private readonly loadPreset: GOPresetConfigLoaderFn;
+  private readonly onInfo: GOPresetConfigLogHandler | undefined;
+  private readonly onWarning: GOPresetConfigLogHandler | undefined;
+  private loaded = false;
+  private presetName: string | undefined;
+
+  constructor(options: GOPresetConfigProviderOptions) {
+    super();
+    this.selectorProviders = options.selectorProviders;
+    this.presetNameParameter = options.presetNameParameter;
+    this.presetFileParameter = options.presetFileParameter;
+    this.schema = options.schema;
+    this.loadPreset = options.loadPreset;
+    this.secretRedactor = new GOSecretRedactor(options.secretsSpecifier ?? GOSecretsSpecifierFactory.none());
+    this.onInfo = options.onInfo;
+    this.onWarning = options.onWarning;
+  }
+
+  prepare(): void {
+    this.reload();
+  }
+
+  getName(): string {
+    return this.presetName === undefined ? 'Preset' : `Preset(${this.presetName})`;
+  }
+
+  override getValue(key: string): string | string[] | undefined {
+    this.ensureLoaded();
+    return super.getValue(key);
+  }
+
+  override hasKey(key: string): boolean {
+    this.ensureLoaded();
+    return super.hasKey(key);
+  }
+
+  override getAllKeys(): string[] {
+    this.ensureLoaded();
+    return super.getAllKeys();
+  }
+
+  isSecret(key: string): boolean {
+    this.ensureLoaded();
+    const value = this.values.get(key);
+    if (value === undefined) return false;
+    return this.secretRedactor.isSecret(key, value);
+  }
+
+  private ensureLoaded(): void {
+    if (!this.loaded) {
+      this.reload();
+    }
+  }
+
+  private reload(): void {
+    this.values = new Map();
+    this.presetName = undefined;
+    this.loaded = false;
+
+    const presetName = this.readSelectorParameterAsString(this.presetNameParameter);
+    const presetFile = this.readSelectorParameterAsString(this.presetFileParameter);
+
+    if (presetName?.trim().length === 0) {
+      throw new Error(`${this.presetNameParameter} cannot be empty`);
+    }
+
+    if (presetFile?.trim().length === 0) {
+      throw new Error(`${this.presetFileParameter} cannot be empty`);
+    }
+
+    if (presetName === undefined) {
+      if (presetFile !== undefined) {
+        this.onWarning?.(
+          `${this.presetFileParameter} is configured but ${this.presetNameParameter} is missing; preset file will be ignored.`,
+        );
+      }
+      this.loaded = true;
+      return;
+    }
+
+    const preset = this.loadPreset({
+      presetName,
+      ...(presetFile !== undefined ? { presetFile } : {}),
+    });
+
+    this.values = new Map(preset.values);
+    this.presetName = preset.name;
+    this.loaded = true;
+
+    if (preset.unknownKeys.length > 0 && preset.allowUnknownKeys) {
+      this.onWarning?.(
+        `Preset "${preset.name}" contains ${preset.unknownKeys.length.toString()} unknown key(s): ${preset.unknownKeys.join(', ')}`,
+      );
+    }
+
+    this.onInfo?.(
+      `Loaded preset '${preset.name}' from ${preset.sourceDisplayPath} (${preset.values.size.toString()} keys)`,
+    );
+  }
+
+  private readSelectorParameterAsString(parameterName: string): string | undefined {
+    const parameter = this.schema.getParameter(parameterName);
+    const keysToTry = parameter === undefined ? [parameterName] : [parameter.name, ...parameter.aliases];
+    const rawValue = this.readRawSelectorValue(keysToTry);
+    return rawValue === undefined ? undefined : GOConfigTypeConverter.toString(rawValue);
+  }
+
+  private readRawSelectorValue(keysToTry: ReadonlyArray<string>): string | string[] | undefined {
+    for (const provider of this.selectorProviders) {
+      for (const key of keysToTry) {
+        if (provider.hasKey(key)) {
+          return provider.getValue(key);
+        }
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
@@ -106,18 +106,18 @@ export class GOPresetConfigProvider extends GOConfigProviderBase {
       throw new Error(`${this.presetNameParameter} cannot be empty`);
     }
 
-    if (presetFile?.length === 0) {
-      throw new Error(`${this.presetFileParameter} cannot be empty`);
-    }
-
     if (presetName === undefined) {
-      if (presetFile !== undefined) {
+      if (presetFile !== undefined && presetFile.length > 0) {
         this.onWarning?.(
           `${this.presetFileParameter} is configured but ${this.presetNameParameter} is missing; preset file will be ignored.`,
         );
       }
       this.loaded = true;
       return;
+    }
+
+    if (presetFile?.length === 0) {
+      throw new Error(`${this.presetFileParameter} cannot be empty`);
     }
 
     const preset = this.loadPreset({

--- a/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
@@ -147,7 +147,24 @@ export class GOPresetConfigProvider extends GOConfigProviderBase {
     const parameter = this.schema.getParameter(parameterName);
     const keysToTry = parameter === undefined ? [parameterName] : [parameter.name, ...parameter.aliases];
     const rawValue = this.readRawSelectorValue(keysToTry);
-    return rawValue === undefined ? undefined : GOConfigTypeConverter.toString(rawValue);
+
+    if (rawValue === undefined) {
+      return undefined;
+    }
+
+    if (Array.isArray(rawValue)) {
+      if (rawValue.length === 0) {
+        throw new Error(`${parameterName} cannot be empty`);
+      }
+
+      if (rawValue.length > 1) {
+        throw new Error(`${parameterName} cannot be specified multiple times`);
+      }
+
+      return rawValue[0] ?? '';
+    }
+
+    return GOConfigTypeConverter.toString(rawValue);
   }
 
   private readRawSelectorValue(keysToTry: ReadonlyArray<string>): string | string[] | undefined {

--- a/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
@@ -99,14 +99,14 @@ export class GOPresetConfigProvider extends GOConfigProviderBase {
     this.presetName = undefined;
     this.loaded = false;
 
-    const presetName = this.readSelectorParameterAsString(this.presetNameParameter);
-    const presetFile = this.readSelectorParameterAsString(this.presetFileParameter);
+    const presetName = this.readSelectorParameterAsString(this.presetNameParameter)?.trim();
+    const presetFile = this.readSelectorParameterAsString(this.presetFileParameter)?.trim();
 
-    if (presetName?.trim().length === 0) {
+    if (presetName?.length === 0) {
       throw new Error(`${this.presetNameParameter} cannot be empty`);
     }
 
-    if (presetFile?.trim().length === 0) {
+    if (presetFile?.length === 0) {
       throw new Error(`${this.presetFileParameter} cannot be empty`);
     }
 

--- a/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOPresetConfigProvider.ts
@@ -34,7 +34,7 @@ export interface GOPresetConfigProviderOptions {
 }
 
 export class GOPresetConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]> = new Map();
+  protected readonly values: Map<string, string | string[]> = new Map();
   private readonly secretRedactor: GOSecretRedactor;
   private readonly selectorProviders: ReadonlyArray<GOConfigProvider>;
   private readonly presetNameParameter: string;
@@ -95,7 +95,7 @@ export class GOPresetConfigProvider extends GOConfigProviderBase {
   }
 
   private reload(): void {
-    this.values = new Map();
+    this.values.clear();
     this.presetName = undefined;
     this.loaded = false;
 
@@ -125,7 +125,10 @@ export class GOPresetConfigProvider extends GOConfigProviderBase {
       ...(presetFile !== undefined ? { presetFile } : {}),
     });
 
-    this.values = new Map(preset.values);
+    this.values.clear();
+    for (const [key, value] of preset.values) {
+      this.values.set(key, value);
+    }
     this.presetName = preset.name;
     this.loaded = true;
 

--- a/packages/go-common/src/libs/core/config/providers/GOYAMLConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOYAMLConfigProvider.ts
@@ -6,13 +6,13 @@
  */
 
 import * as fs from 'fs';
+import { GOConfigObjectFlattener } from '../GOConfigObjectFlattener.js';
 import { GOConfigProviderBase } from '../GOConfigProvider.js';
 import { GOSecretRedactor, GOSecretsSpecifierFactory } from '../GOSecretsSpecifier.js';
 import type { GOSecretsSpecifier } from '../GOSecretsSpecifier.js';
 import { GOYAMLParser, isYAMLObject } from '../parsers/GOYAMLParser.js';
 import type { YAMLValue } from '../parsers/GOYAMLParser.js';
 import { getErrorMessage } from '../../errors/GOErrorUtils.js';
-import { valueToString } from '../../utils/GOValueToString.js';
 
 /**
  * Options for YAML config provider
@@ -105,51 +105,10 @@ export class GOYAMLConfigProvider extends GOConfigProviderBase {
    * Load configuration from YAML object
    */
   private loadFromData(data: Record<string, YAMLValue> | Record<string, unknown>): void {
-    const flattened = this.flattenObject(data);
+    const flattened = GOConfigObjectFlattener.flatten(data);
     for (const [key, value] of flattened) {
       this.values.set(key, value);
     }
-  }
-
-  /**
-   * Flatten nested object into dot-notation keys
-   *
-   * @example
-   * { http: { client: { timeout: 60 } } } -> { "http.client.timeout": "60" }
-   */
-  private flattenObject(
-    obj: Record<string, YAMLValue> | Record<string, unknown>,
-    prefix = '',
-  ): Map<string, string | string[]> {
-    const result = new Map<string, string | string[]>();
-
-    for (const [key, value] of Object.entries(obj)) {
-      const fullKey = prefix ? `${prefix}.${key}` : key;
-
-      if (value === null || value === undefined) {
-        // Skip null/undefined values
-        continue;
-      }
-
-      if (Array.isArray(value)) {
-        // Handle arrays - convert all elements to strings
-        result.set(
-          fullKey,
-          value.map((v) => valueToString(v)),
-        );
-      } else if (typeof value === 'object' && !Buffer.isBuffer(value) && !(value instanceof Date)) {
-        // Recursively flatten nested objects (but not Dates)
-        const nested = this.flattenObject(value as Record<string, unknown>, fullKey);
-        for (const [nestedKey, nestedValue] of nested) {
-          result.set(nestedKey, nestedValue);
-        }
-      } else {
-        // Primitive values (including Date)
-        result.set(fullKey, valueToString(value));
-      }
-    }
-
-    return result;
   }
 
   /**

--- a/packages/go-common/src/libs/core/config/providers/GOYAMLConfigProvider.ts
+++ b/packages/go-common/src/libs/core/config/providers/GOYAMLConfigProvider.ts
@@ -41,7 +41,7 @@ export interface GOYAMLConfigProviderOptions {
  * YAML configuration provider
  */
 export class GOYAMLConfigProvider extends GOConfigProviderBase {
-  protected values: Map<string, string | string[]>;
+  protected readonly values: Map<string, string | string[]>;
   private readonly secretRedactor: GOSecretRedactor;
   private readonly filePath?: string | undefined;
   private readonly isOptional: boolean;

--- a/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
+++ b/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { GOConfigSchema } from '../../GOConfigSchema.js';
+import { GOInMemoryConfigProvider } from '../GOInMemoryConfigProvider.js';
+import { GOPresetConfigProvider } from '../GOPresetConfigProvider.js';
+import { GOSecretsSpecifierFactory } from '../../GOSecretsSpecifier.js';
+import type { GOSecretsSpecifier } from '../../GOSecretsSpecifier.js';
+
+const PRESET_NAME_PARAMETER = 'script.preset.name';
+const PRESET_FILE_PARAMETER = 'script.preset.file';
+
+function createSchema(): GOConfigSchema {
+  return {
+    getParameter: (name: string) => {
+      if (name === PRESET_NAME_PARAMETER) {
+        return { name, aliases: ['spn'] };
+      }
+      if (name === PRESET_FILE_PARAMETER) {
+        return { name, aliases: ['spf'] };
+      }
+      return undefined;
+    },
+  } as unknown as GOConfigSchema;
+}
+
+function createPresetProvider(
+  options: {
+    readonly selectorValues?: Record<string, string | string[]>;
+    readonly warnings?: string[];
+    readonly infos?: string[];
+    readonly secrets?: GOSecretsSpecifier;
+  } = {},
+): GOPresetConfigProvider {
+  const selectorProvider = new GOInMemoryConfigProvider({
+    ...(options.selectorValues !== undefined ? { values: options.selectorValues } : {}),
+  });
+
+  return new GOPresetConfigProvider({
+    selectorProviders: [selectorProvider],
+    presetNameParameter: PRESET_NAME_PARAMETER,
+    presetFileParameter: PRESET_FILE_PARAMETER,
+    schema: createSchema(),
+    loadPreset: (selection) => ({
+      name: selection.presetName,
+      sourcePath: '/tmp/presets.yaml',
+      sourceDisplayPath: selection.presetFile ?? 'presets.yaml',
+      values: new Map<string, string | string[]>([
+        ['athena.database', `${selection.presetName}_analytics`],
+        ['analysis.rules', ['a', 'b']],
+        ['slack.token', 'xoxb-secret'],
+      ]),
+      unknownKeys: [],
+      allowUnknownKeys: true,
+    }),
+    ...(options.secrets !== undefined ? { secretsSpecifier: options.secrets } : {}),
+    onWarning: (message) => options.warnings?.push(message),
+    onInfo: (message) => options.infos?.push(message),
+  });
+}
+
+describe('GOPresetConfigProvider', () => {
+  it('stays empty when no preset name is configured', () => {
+    const provider = createPresetProvider();
+
+    assert.strictEqual(provider.getName(), 'Preset');
+    assert.strictEqual(provider.hasKey('athena.database'), false);
+    assert.deepStrictEqual(provider.getAllKeys(), []);
+  });
+
+  it('loads preset values lazily from selector providers', () => {
+    const infos: string[] = [];
+    const provider = createPresetProvider({
+      selectorValues: {
+        [PRESET_NAME_PARAMETER]: 'tppmessages',
+      },
+      infos,
+    });
+
+    assert.strictEqual(provider.hasKey('athena.database'), true);
+    assert.strictEqual(provider.getName(), 'Preset(tppmessages)');
+    assert.strictEqual(provider.getValue('athena.database'), 'tppmessages_analytics');
+    assert.deepStrictEqual(provider.getValue('analysis.rules'), ['a', 'b']);
+    assert.deepStrictEqual(provider.getAllKeys().sort(), ['analysis.rules', 'athena.database', 'slack.token']);
+    assert.deepStrictEqual(infos, ["Loaded preset 'tppmessages' from presets.yaml (3 keys)"]);
+  });
+
+  it('resolves preset selector aliases', () => {
+    const provider = createPresetProvider({
+      selectorValues: {
+        spn: 'prod',
+        spf: 'presets.prod.yaml',
+      },
+    });
+
+    assert.strictEqual(provider.getValue('athena.database'), 'prod_analytics');
+    assert.strictEqual(provider.getName(), 'Preset(prod)');
+  });
+
+  it('warns when preset file is configured without preset name', () => {
+    const warnings: string[] = [];
+    const provider = createPresetProvider({
+      selectorValues: {
+        [PRESET_FILE_PARAMETER]: 'presets.prod.yaml',
+      },
+      warnings,
+    });
+
+    provider.prepare();
+
+    assert.strictEqual(provider.hasKey('athena.database'), false);
+    assert.deepStrictEqual(warnings, [
+      `${PRESET_FILE_PARAMETER} is configured but ${PRESET_NAME_PARAMETER} is missing; preset file will be ignored.`,
+    ]);
+  });
+
+  it('refreshes preset values on prepare', () => {
+    const selectorProvider = new GOInMemoryConfigProvider({
+      values: {
+        [PRESET_NAME_PARAMETER]: 'dev',
+      },
+    });
+    const provider = new GOPresetConfigProvider({
+      selectorProviders: [selectorProvider],
+      presetNameParameter: PRESET_NAME_PARAMETER,
+      presetFileParameter: PRESET_FILE_PARAMETER,
+      schema: createSchema(),
+      loadPreset: (selection) => ({
+        name: selection.presetName,
+        sourcePath: '/tmp/presets.yaml',
+        sourceDisplayPath: 'presets.yaml',
+        values: new Map([['athena.database', selection.presetName]]),
+        unknownKeys: [],
+        allowUnknownKeys: true,
+      }),
+    });
+
+    provider.prepare();
+    assert.strictEqual(provider.getValue('athena.database'), 'dev');
+
+    selectorProvider.setValue(PRESET_NAME_PARAMETER, 'prod');
+    provider.prepare();
+    assert.strictEqual(provider.getValue('athena.database'), 'prod');
+  });
+
+  it('redacts values using the configured secret specifier', () => {
+    const provider = createPresetProvider({
+      selectorValues: {
+        [PRESET_NAME_PARAMETER]: 'prod',
+      },
+      secrets: GOSecretsSpecifierFactory.specific(['slack.token']),
+    });
+
+    assert.strictEqual(provider.isSecret('slack.token'), true);
+    assert.strictEqual(provider.getDisplayValue('slack.token'), '[REDACTED (11 chars)]');
+  });
+});

--- a/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
+++ b/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
@@ -202,6 +202,21 @@ describe('GOPresetConfigProvider', () => {
     ]);
   });
 
+  it('ignores an empty preset file when no preset name is configured', () => {
+    const warnings: string[] = [];
+    const provider = createPresetProvider({
+      selectorValues: {
+        [PRESET_FILE_PARAMETER]: '   ',
+      },
+      warnings,
+    });
+
+    provider.prepare();
+
+    assert.strictEqual(provider.hasKey('athena.database'), false);
+    assert.deepStrictEqual(warnings, []);
+  });
+
   it('refreshes preset values on prepare', () => {
     const selectorProvider = new GOInMemoryConfigProvider({
       values: {

--- a/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
+++ b/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
@@ -151,6 +151,46 @@ describe('GOPresetConfigProvider', () => {
     assert.throws(() => provider.prepare(), /script\.preset\.name cannot be empty/);
   });
 
+  it('rejects empty preset selector arrays', () => {
+    const presetNameProvider = createPresetProvider({
+      selectorValues: {
+        [PRESET_NAME_PARAMETER]: [],
+      },
+    });
+    const presetFileProvider = createPresetProvider({
+      selectorValues: {
+        [PRESET_NAME_PARAMETER]: 'prod',
+        [PRESET_FILE_PARAMETER]: [],
+      },
+    });
+
+    assert.throws(() => presetNameProvider.prepare(), /script\.preset\.name cannot be empty/);
+    assert.throws(() => presetFileProvider.prepare(), /script\.preset\.file cannot be empty/);
+  });
+
+  it('rejects repeated preset selector values', () => {
+    const presetNameProvider = createPresetProvider({
+      selectorValues: {
+        [PRESET_NAME_PARAMETER]: ['dev', 'prod'],
+      },
+    });
+    const presetFileProvider = createPresetProvider({
+      selectorValues: {
+        [PRESET_NAME_PARAMETER]: 'prod',
+        [PRESET_FILE_PARAMETER]: ['presets.dev.yaml', 'presets.prod.yaml'],
+      },
+    });
+
+    assert.throws(
+      () => presetNameProvider.prepare(),
+      /script\.preset\.name cannot be specified multiple times/,
+    );
+    assert.throws(
+      () => presetFileProvider.prepare(),
+      /script\.preset\.file cannot be specified multiple times/,
+    );
+  });
+
   it('warns when preset file is configured without preset name', () => {
     const warnings: string[] = [];
     const provider = createPresetProvider({

--- a/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
+++ b/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
@@ -181,14 +181,8 @@ describe('GOPresetConfigProvider', () => {
       },
     });
 
-    assert.throws(
-      () => presetNameProvider.prepare(),
-      /script\.preset\.name cannot be specified multiple times/,
-    );
-    assert.throws(
-      () => presetFileProvider.prepare(),
-      /script\.preset\.file cannot be specified multiple times/,
-    );
+    assert.throws(() => presetNameProvider.prepare(), /script\.preset\.name cannot be specified multiple times/);
+    assert.throws(() => presetFileProvider.prepare(), /script\.preset\.file cannot be specified multiple times/);
   });
 
   it('warns when preset file is configured without preset name', () => {

--- a/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
+++ b/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
@@ -97,6 +97,40 @@ describe('GOPresetConfigProvider', () => {
     assert.strictEqual(provider.getName(), 'Preset(prod)');
   });
 
+  it('trims preset selector values before loading the preset', () => {
+    const selections: { readonly presetName: string; readonly presetFile?: string }[] = [];
+    const provider = new GOPresetConfigProvider({
+      selectorProviders: [
+        new GOInMemoryConfigProvider({
+          values: {
+            [PRESET_NAME_PARAMETER]: '  prod  ',
+            [PRESET_FILE_PARAMETER]: '  presets.prod.yaml  ',
+          },
+        }),
+      ],
+      presetNameParameter: PRESET_NAME_PARAMETER,
+      presetFileParameter: PRESET_FILE_PARAMETER,
+      schema: createSchema(),
+      loadPreset: (selection) => {
+        selections.push(selection);
+        return {
+          name: selection.presetName,
+          sourcePath: '/tmp/presets.yaml',
+          sourceDisplayPath: selection.presetFile ?? 'presets.yaml',
+          values: new Map([['athena.database', selection.presetName]]),
+          unknownKeys: [],
+          allowUnknownKeys: true,
+        };
+      },
+    });
+
+    provider.prepare();
+
+    assert.deepStrictEqual(selections, [{ presetName: 'prod', presetFile: 'presets.prod.yaml' }]);
+    assert.strictEqual(provider.getName(), 'Preset(prod)');
+    assert.strictEqual(provider.getValue('athena.database'), 'prod');
+  });
+
   it('rejects an empty preset name supplied by a selector provider', () => {
     const provider = new GOPresetConfigProvider({
       selectorProviders: [

--- a/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
+++ b/packages/go-common/src/libs/core/config/providers/__tests__/GOPresetConfigProvider.test.ts
@@ -97,6 +97,26 @@ describe('GOPresetConfigProvider', () => {
     assert.strictEqual(provider.getName(), 'Preset(prod)');
   });
 
+  it('rejects an empty preset name supplied by a selector provider', () => {
+    const provider = new GOPresetConfigProvider({
+      selectorProviders: [
+        new GOInMemoryConfigProvider({
+          values: {
+            [PRESET_NAME_PARAMETER]: '',
+          },
+        }),
+      ],
+      presetNameParameter: PRESET_NAME_PARAMETER,
+      presetFileParameter: PRESET_FILE_PARAMETER,
+      schema: createSchema(),
+      loadPreset: () => {
+        throw new Error('loadPreset should not be called');
+      },
+    });
+
+    assert.throws(() => provider.prepare(), /script\.preset\.name cannot be empty/);
+  });
+
   it('warns when preset file is configured without preset name', () => {
     const warnings: string[] = [];
     const provider = createPresetProvider({

--- a/packages/go-common/src/libs/core/script/GOPresetUnknownKeysError.ts
+++ b/packages/go-common/src/libs/core/script/GOPresetUnknownKeysError.ts
@@ -1,0 +1,53 @@
+export interface GOPresetUnknownKeysErrorOptions {
+  readonly presetName: string;
+  readonly unknownKeys: ReadonlyArray<string>;
+  readonly knownKeys: ReadonlyArray<string>;
+  readonly suggestions: Readonly<Record<string, string>>;
+}
+
+export class GOPresetUnknownKeysError extends Error {
+  readonly presetName: string;
+  readonly unknownKeys: ReadonlyArray<string>;
+  readonly knownKeys: ReadonlyArray<string>;
+  readonly suggestions: Readonly<Record<string, string>>;
+
+  constructor(options: GOPresetUnknownKeysErrorOptions) {
+    super(formatPresetUnknownKeysMessage(options.presetName, options.unknownKeys, options.suggestions));
+    this.name = 'GOPresetUnknownKeysError';
+    this.presetName = options.presetName;
+    this.unknownKeys = Object.freeze([...options.unknownKeys]);
+    this.knownKeys = Object.freeze([...options.knownKeys]);
+    this.suggestions = freezeSuggestions(options.suggestions);
+  }
+}
+
+function freezeSuggestions(suggestions: Readonly<Record<string, string>>): Readonly<Record<string, string>> {
+  const copy = Object.create(null) as Record<string, string>;
+
+  for (const [key, value] of Object.entries(suggestions)) {
+    copy[key] = value;
+  }
+
+  return Object.freeze(copy);
+}
+
+function formatPresetUnknownKeysMessage(
+  presetName: string,
+  unknownKeys: ReadonlyArray<string>,
+  suggestions: Readonly<Record<string, string>>,
+): string {
+  if (unknownKeys.length === 1) {
+    const key = unknownKeys[0] ?? '';
+    const suggestion = suggestions[key];
+    return suggestion === undefined
+      ? `Preset "${presetName}" contains unknown key "${key}"`
+      : `Preset "${presetName}" contains unknown key "${key}". Did you mean "${suggestion}"?`;
+  }
+
+  const lines = [`Preset "${presetName}" contains ${String(unknownKeys.length)} unknown key(s):`];
+  for (const key of unknownKeys) {
+    const suggestion = suggestions[key];
+    lines.push(suggestion === undefined ? `  - ${key}` : `  - ${key} (did you mean "${suggestion}"?)`);
+  }
+  return lines.join('\n');
+}

--- a/packages/go-common/src/libs/core/script/GOScript.ts
+++ b/packages/go-common/src/libs/core/script/GOScript.ts
@@ -37,7 +37,7 @@ import { GOScriptPresetLoader } from './GOScriptPresetLoader.js';
 import {
   GOSCRIPT_PRESET_FILE_PARAMETER,
   GOSCRIPT_PRESET_NAME_PARAMETER,
-  getGOScriptSystemParameters,
+  GOSCRIPT_SYSTEM_PARAMETERS,
 } from './GOScriptSystemParameters.js';
 import type {
   GOScriptOptions,
@@ -380,7 +380,7 @@ export class GOScript {
       schema.addParameters(configOptions.parameters);
     }
 
-    schema.addReservedParameters(getGOScriptSystemParameters());
+    schema.addReservedParameters(GOSCRIPT_SYSTEM_PARAMETERS);
 
     return schema;
   }

--- a/packages/go-common/src/libs/core/script/GOScript.ts
+++ b/packages/go-common/src/libs/core/script/GOScript.ts
@@ -13,6 +13,7 @@ import { GOCommandLineConfigProvider } from '../config/providers/GOCommandLineCo
 import { GOEnvironmentConfigProvider } from '../config/providers/GOEnvironmentConfigProvider.js';
 import { GOJSONConfigProvider } from '../config/providers/GOJSONConfigProvider.js';
 import { GOLambdaEventConfigProvider } from '../config/providers/GOLambdaEventConfigProvider.js';
+import { GOPresetConfigProvider } from '../config/providers/GOPresetConfigProvider.js';
 import { GOYAMLConfigProvider } from '../config/providers/GOYAMLConfigProvider.js';
 import { GOUnknownParameterDetector } from '../config/validation/GOUnknownParameterDetector.js';
 import { GOCredentialSource } from '../environment/GOCredentialSource.js';
@@ -32,6 +33,12 @@ import type { GOPathTypeValue } from '../utils/index.js';
 
 import { GOScriptConfigLoader } from './GOScriptConfigLoader.js';
 import { defaultAwsCredentialsOptions, configTableWidths } from './GOScriptDefaults.js';
+import { GOScriptPresetLoader } from './GOScriptPresetLoader.js';
+import {
+  GOSCRIPT_PRESET_FILE_PARAMETER,
+  GOSCRIPT_PRESET_NAME_PARAMETER,
+  getGOScriptSystemParameters,
+} from './GOScriptSystemParameters.js';
 import type {
   GOScriptOptions,
   GOScriptMetadata,
@@ -126,11 +133,12 @@ export class GOScript {
     this.prompt = new GOPrompt(this.logger);
 
     // Initialize config schema and reader
-    this.configReader = this.initializeConfigReader(options.config);
     this.configSchema = this.initializeConfigSchema(options.config);
+    const configProviders = this.initializeConfigProviders(options.config);
+    this.configReader = new GOConfigReader(configProviders);
 
     // Initialize config loader (with fallback context so asyncFallback functions can access GOPaths)
-    this.configLoader = new GOScriptConfigLoader(this.configSchema, this.configReader, { paths: this.paths });
+    this.configLoader = this.createConfigLoader(this.configReader);
 
     // Initialize credentials manager if needed
     this.credentialsManager = this.initializeCredentialManager(options.config);
@@ -234,7 +242,7 @@ export class GOScript {
   /**
    * Initialize configuration reader
    */
-  private initializeConfigReader(configOptions?: GOScriptConfigOptions): GOConfigReader {
+  private initializeConfigProviders(configOptions?: GOScriptConfigOptions): ReadonlyArray<GOConfigProvider> {
     // Get config file paths with resolution info
     const jsonConfigInfo = this.paths.getConfigFilePathWithInfo('config.json');
     const yamlConfigInfo = this.paths.getConfigFilePathWithInfo('config.yaml');
@@ -256,11 +264,10 @@ export class GOScript {
         ? `Environment(data/${this.paths.getScriptName()}/configs/.env)`
         : `Environment(configs/.env)`;
 
-    let configProviders: ReadonlyArray<GOConfigProvider>;
     try {
       if (configOptions?.configProviders) {
         // Custom providers: skip CLI provider tracking (cannot assume structure)
-        configProviders = configOptions.configProviders;
+        return this.appendPresetConfigProvider(configOptions.configProviders);
       } else {
         // Shared file/env providers — identical for both Lambda and local/CI
         const sharedProviders: GOConfigProvider[] = [
@@ -286,12 +293,12 @@ export class GOScript {
           // createLambdaHandler before loadConfig is called).
           const eventProvider = new GOLambdaEventConfigProvider({});
           this.lambdaEventProvider = eventProvider;
-          configProviders = [eventProvider, ...sharedProviders];
+          return this.appendPresetConfigProvider([eventProvider, ...sharedProviders]);
         } else {
           // Local / CI: track CLI provider for unknown parameter detection
           const cliProvider = new GOCommandLineConfigProvider();
           this.cliProvider = cliProvider;
-          configProviders = [cliProvider, ...sharedProviders];
+          return this.appendPresetConfigProvider([cliProvider, ...sharedProviders]);
         }
       }
     } catch (error: unknown) {
@@ -309,9 +316,33 @@ export class GOScript {
       // CLI entry points wrap the script in .catch(() => process.exit(1)).
       throw error instanceof Error ? error : new Error(errorMessage);
     }
+  }
 
-    const configReader = new GOConfigReader(configProviders);
-    return configReader;
+  private appendPresetConfigProvider(
+    selectorProviders: ReadonlyArray<GOConfigProvider>,
+  ): ReadonlyArray<GOConfigProvider> {
+    const presetProvider = new GOPresetConfigProvider({
+      selectorProviders,
+      presetNameParameter: GOSCRIPT_PRESET_NAME_PARAMETER,
+      presetFileParameter: GOSCRIPT_PRESET_FILE_PARAMETER,
+      schema: this.configSchema,
+      loadPreset: (selection) =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: selection.presetName,
+          ...(selection.presetFile !== undefined ? { presetFile: selection.presetFile } : {}),
+          paths: this.paths,
+          schema: this.configSchema,
+        }),
+      ...(this.options.config?.secrets !== undefined ? { secretsSpecifier: this.options.config.secrets } : {}),
+      onInfo: (message) => this.logger.info(message),
+      onWarning: (message) => this.logger.warning(message),
+    });
+
+    return [...selectorProviders, presetProvider];
+  }
+
+  private createConfigLoader(configReader: GOConfigReader): GOScriptConfigLoader {
+    return new GOScriptConfigLoader(this.configSchema, configReader, { paths: this.paths });
   }
 
   /**
@@ -348,6 +379,8 @@ export class GOScript {
     if (configOptions?.parameters) {
       schema.addParameters(configOptions.parameters);
     }
+
+    schema.addReservedParameters(getGOScriptSystemParameters());
 
     return schema;
   }
@@ -447,6 +480,9 @@ export class GOScript {
       }
     }
 
+    this.validateCliSystemParameterHasValue(GOSCRIPT_PRESET_NAME_PARAMETER);
+    this.validateCliSystemParameterHasValue(GOSCRIPT_PRESET_FILE_PARAMETER);
+
     const loadResult = await this.configLoader.load();
     this.configValues = loadResult.values;
     this.configSources = loadResult.sources;
@@ -514,6 +550,10 @@ export class GOScript {
     const result = {} as TConfiguration;
 
     for (const param of this.configSchema.getAllParameters()) {
+      if (param.reserved) {
+        continue;
+      }
+
       const propertyName = this.parameterNameToPropertyName(param.name);
       const finalPropertyName = (propertyMapping?.[propertyName as keyof TConfiguration] ??
         propertyName) as keyof TConfiguration;
@@ -540,6 +580,57 @@ export class GOScript {
       .split('.')
       .map((part, i) => (i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
       .join('');
+  }
+
+  private validateCliSystemParameterHasValue(parameterName: string): void {
+    if (this.cliProvider === undefined) {
+      return;
+    }
+
+    const parameter = this.configSchema.getParameter(parameterName);
+    if (parameter === undefined) {
+      return;
+    }
+
+    const rawArgs = this.cliProvider.getRawArguments();
+    const flagForms = this.getCliFlagForms(parameter.getAllCliFlags());
+
+    for (let index = 0; index < rawArgs.length; index++) {
+      const arg = rawArgs[index];
+      if (arg === undefined) {
+        continue;
+      }
+
+      for (const flag of flagForms) {
+        if (arg === flag) {
+          const nextArg = rawArgs[index + 1];
+          if (nextArg === undefined || nextArg.startsWith('-')) {
+            throw new Error(`${parameter.name} cannot be empty`);
+          }
+        }
+
+        const inlinePrefix = `${flag}=`;
+        if (arg.startsWith(inlinePrefix) && arg.slice(inlinePrefix.length).trim().length === 0) {
+          throw new Error(`${parameter.name} cannot be empty`);
+        }
+      }
+    }
+  }
+
+  private getCliFlagForms(flags: ReadonlyArray<string>): ReadonlySet<string> {
+    const forms = new Set<string>();
+
+    for (const flag of flags) {
+      if (flag.startsWith('-')) {
+        forms.add(flag);
+        continue;
+      }
+
+      forms.add(`-${flag}`);
+      forms.add(`--${flag}`);
+    }
+
+    return forms;
   }
 
   // ============================================================================

--- a/packages/go-common/src/libs/core/script/GOScriptConfigLoader.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptConfigLoader.ts
@@ -38,6 +38,8 @@ export class GOScriptConfigLoader {
    * Load configuration values from all providers
    */
   async load(): Promise<ConfigLoadResult> {
+    await this.configReader.prepareProviders();
+
     // Load configuration values using type handlers (now async for fallback support)
     const configValues = await this.loadConfigValues();
 

--- a/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
@@ -7,6 +7,7 @@ import type { GOConfigSchema } from '../config/GOConfigSchema.js';
 import { GOYAMLParser } from '../config/parsers/GOYAMLParser.js';
 import { damerauLevenshteinDistance } from '../config/validation/GOStringDistance.js';
 import { getErrorMessage } from '../errors/GOErrorUtils.js';
+import { isDangerousKey } from '../security/DangerousKeys.js';
 import { GOPathType, type GOPaths } from '../utils/GOPaths.js';
 
 export interface GOScriptPresetDefinition {
@@ -38,6 +39,20 @@ export interface GOScriptPresetLoaderOptions {
   readonly schema: GOConfigSchema;
 }
 
+type GOScriptPresetExistsSyncFn = (filePath: string) => boolean;
+type GOScriptPresetRealpathSyncFn = (filePath: string) => string;
+type GOScriptPresetReadFileSyncFn = (filePath: string, encoding: BufferEncoding) => string;
+
+export interface GOScriptPresetLoaderFileSystem {
+  readonly existsSync: GOScriptPresetExistsSyncFn;
+  readonly realpathSync: GOScriptPresetRealpathSyncFn;
+  readonly readFileSync: GOScriptPresetReadFileSyncFn;
+}
+
+export interface GOScriptPresetLoaderDependencies {
+  readonly fileSystem?: GOScriptPresetLoaderFileSystem;
+}
+
 interface ResolvedPresetFile {
   readonly path: string;
   readonly displayPath: string;
@@ -45,11 +60,23 @@ interface ResolvedPresetFile {
 
 const DEFAULT_PRESET_FILE_NAMES = ['presets.yaml', 'presets.yml', 'presets.json'] as const;
 const SUPPORTED_PRESET_EXTENSIONS = new Set(['.yaml', '.yml', '.json']);
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const DEFAULT_ALLOW_UNKNOWN_KEYS = true;
 const MAX_SUGGESTION_DISTANCE = 3;
+const MAX_PRESET_STRUCTURE_DEPTH = 64;
+
+const NODE_PRESET_FILE_SYSTEM: GOScriptPresetLoaderFileSystem = {
+  existsSync: (filePath) => fs.existsSync(filePath),
+  realpathSync: (filePath) => fs.realpathSync(filePath),
+  readFileSync: (filePath, encoding) => fs.readFileSync(filePath, encoding),
+};
 
 export class GOScriptPresetLoader {
+  private readonly fileSystem: GOScriptPresetLoaderFileSystem;
+
+  constructor(dependencies: GOScriptPresetLoaderDependencies = {}) {
+    this.fileSystem = dependencies.fileSystem ?? NODE_PRESET_FILE_SYSTEM;
+  }
+
   loadSelectedPreset(options: GOScriptPresetLoaderOptions): GOScriptPresetResolution {
     const presetName = this.normalizePresetName(options.presetName);
     const resolvedFile = this.resolvePresetFile({
@@ -62,10 +89,11 @@ export class GOScriptPresetLoader {
     const preset = this.selectPreset(presetFile.presets, presetName, resolvedFile.displayPath);
     const allowUnknownKeys = preset.allowUnknownKeys ?? presetFile.allowUnknownKeys ?? DEFAULT_ALLOW_UNKNOWN_KEYS;
     const values = GOConfigObjectFlattener.flatten(preset.values);
-    const unknownKeys = this.findUnknownKeys(values, options.schema);
+    const knownKeys = this.buildKnownConfigKeys(options.schema);
+    const unknownKeys = this.findUnknownKeys(values, knownKeys);
 
     if (unknownKeys.length > 0 && !allowUnknownKeys) {
-      throw new Error(this.formatUnknownKeysError(presetName, unknownKeys, options.schema));
+      throw new Error(this.formatUnknownKeysError(presetName, unknownKeys, knownKeys));
     }
 
     return {
@@ -107,7 +135,7 @@ export class GOScriptPresetLoader {
       this.validatePresetFileExtension(presetFile);
       const resolvedPath = this.resolveCustomPresetFile(presetFile, options.paths);
 
-      if (!fs.existsSync(resolvedPath)) {
+      if (!this.fileSystem.existsSync(resolvedPath)) {
         throw new Error(`Preset "${options.presetName}" requested but preset file "${presetFile}" was not found.`);
       }
 
@@ -145,7 +173,7 @@ export class GOScriptPresetLoader {
   }
 
   private validatePresetFilePath(filePath: string, displayPath: string, paths: GOPaths): string {
-    const realFilePath = fs.realpathSync(filePath);
+    const realFilePath = this.fileSystem.realpathSync(filePath);
     const allowedRoots = this.getAllowedPresetRoots(paths);
     const isAllowed = allowedRoots.some((root) => this.isPathInsideRoot(realFilePath, root));
 
@@ -163,7 +191,7 @@ export class GOScriptPresetLoader {
   }
 
   private realpathOrResolve(rootPath: string): string {
-    return fs.existsSync(rootPath) ? fs.realpathSync(rootPath) : path.resolve(rootPath);
+    return this.fileSystem.existsSync(rootPath) ? this.fileSystem.realpathSync(rootPath) : path.resolve(rootPath);
   }
 
   private isPathInsideRoot(filePath: string, rootPath: string): boolean {
@@ -189,13 +217,14 @@ export class GOScriptPresetLoader {
     const extension = path.extname(filePath).toLowerCase();
 
     try {
+      const content = this.fileSystem.readFileSync(filePath, 'utf8');
+
       if (extension === '.json') {
-        const content = fs.readFileSync(filePath, 'utf8');
         const normalizedContent = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
         return JSON.parse(normalizedContent) as unknown;
       }
 
-      return GOYAMLParser.parseFile(filePath);
+      return GOYAMLParser.parseContent(content);
     } catch (error: unknown) {
       throw new Error(`Failed to load presets file ${filePath}: ${getErrorMessage(error)}`, { cause: error });
     }
@@ -276,6 +305,7 @@ export class GOScriptPresetLoader {
     sourcePath: string,
   ): ReadonlyArray<GOScriptPresetDefinition> {
     const presets: GOScriptPresetDefinition[] = [];
+    const names = new Set<string>();
 
     for (const [name, values] of Object.entries(data)) {
       this.assertSafeKey(name, sourcePath);
@@ -284,6 +314,11 @@ export class GOScriptPresetLoader {
       if (normalizedName.length === 0) {
         throw new Error(`Invalid preset name in ${sourcePath}. Preset name cannot be empty.`);
       }
+
+      if (names.has(normalizedName)) {
+        throw new Error(`Duplicate preset name "${normalizedName}" in ${sourcePath}`);
+      }
+      names.add(normalizedName);
 
       if (!this.isRecord(values)) {
         throw new Error(`Preset "${normalizedName}" in ${sourcePath} must be an object`);
@@ -317,9 +352,8 @@ export class GOScriptPresetLoader {
 
   private findUnknownKeys(
     values: ReadonlyMap<string, GOFlattenedConfigValue>,
-    schema: GOConfigSchema,
+    knownKeys: ReadonlySet<string>,
   ): ReadonlyArray<string> {
-    const knownKeys = this.buildKnownConfigKeys(schema);
     return Array.from(values.keys()).filter((key) => !knownKeys.has(key));
   }
 
@@ -339,13 +373,13 @@ export class GOScriptPresetLoader {
   private formatUnknownKeysError(
     presetName: string,
     unknownKeys: ReadonlyArray<string>,
-    schema: GOConfigSchema,
+    knownKeys: ReadonlySet<string>,
   ): string {
-    const knownKeys = Array.from(this.buildKnownConfigKeys(schema));
+    const knownKeyList = Array.from(knownKeys);
 
     if (unknownKeys.length === 1) {
       const key = unknownKeys[0] ?? '';
-      const suggestion = this.findClosestKnownKey(key, knownKeys);
+      const suggestion = this.findClosestKnownKey(key, knownKeyList);
       return suggestion === undefined
         ? `Preset "${presetName}" contains unknown key "${key}"`
         : `Preset "${presetName}" contains unknown key "${key}". Did you mean "${suggestion}"?`;
@@ -353,7 +387,7 @@ export class GOScriptPresetLoader {
 
     const lines = [`Preset "${presetName}" contains ${String(unknownKeys.length)} unknown key(s):`];
     for (const key of unknownKeys) {
-      const suggestion = this.findClosestKnownKey(key, knownKeys);
+      const suggestion = this.findClosestKnownKey(key, knownKeyList);
       lines.push(suggestion === undefined ? `  - ${key}` : `  - ${key} (did you mean "${suggestion}"?)`);
     }
     return lines.join('\n');
@@ -409,28 +443,41 @@ export class GOScriptPresetLoader {
     return value;
   }
 
-  private assertNoDangerousKeys(data: Record<string, unknown>, location: string): void {
+  private assertNoDangerousKeys(data: Record<string, unknown>, location: string, depth = 0): void {
+    this.assertWithinDepth(location, depth);
+
     for (const [key, value] of Object.entries(data)) {
       this.assertSafeKey(key, location);
+      this.assertNoDangerousKeysInValue(value, `${location}.${key}`, depth + 1);
+    }
+  }
 
-      if (Array.isArray(value)) {
-        value.forEach((item, index) => {
-          if (this.isRecord(item)) {
-            this.assertNoDangerousKeys(item, `${location}.${key}[${String(index)}]`);
-          }
-        });
-        continue;
-      }
+  private assertNoDangerousKeysInValue(value: unknown, location: string, depth: number): void {
+    this.assertWithinDepth(location, depth);
 
-      if (this.isRecord(value)) {
-        this.assertNoDangerousKeys(value, `${location}.${key}`);
-      }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => {
+        this.assertNoDangerousKeysInValue(item, `${location}[${String(index)}]`, depth + 1);
+      });
+      return;
+    }
+
+    if (this.isRecord(value)) {
+      this.assertNoDangerousKeys(value, location, depth);
     }
   }
 
   private assertSafeKey(key: string, location: string): void {
-    if (DANGEROUS_KEYS.has(key)) {
+    if (isDangerousKey(key)) {
       throw new Error(`Unsafe preset key "${location}.${key}" is not allowed`);
+    }
+  }
+
+  private assertWithinDepth(location: string, depth: number): void {
+    if (depth > MAX_PRESET_STRUCTURE_DEPTH) {
+      throw new Error(
+        `Preset structure exceeds maximum depth of ${String(MAX_PRESET_STRUCTURE_DEPTH)} at "${location}"`,
+      );
     }
   }
 

--- a/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
@@ -1,0 +1,440 @@
+import fs from 'fs';
+import path from 'path';
+
+import { GOConfigObjectFlattener } from '../config/GOConfigObjectFlattener.js';
+import type { GOFlattenedConfigValue } from '../config/GOConfigObjectFlattener.js';
+import type { GOConfigSchema } from '../config/GOConfigSchema.js';
+import { GOYAMLParser } from '../config/parsers/GOYAMLParser.js';
+import { damerauLevenshteinDistance } from '../config/validation/GOStringDistance.js';
+import { getErrorMessage } from '../errors/GOErrorUtils.js';
+import { GOPathType, type GOPaths } from '../utils/GOPaths.js';
+
+export interface GOScriptPresetDefinition {
+  readonly name: string;
+  readonly description?: string;
+  readonly allowUnknownKeys?: boolean;
+  readonly values: Record<string, unknown>;
+}
+
+export interface GOScriptPresetFile {
+  readonly version?: number;
+  readonly allowUnknownKeys?: boolean;
+  readonly presets: ReadonlyArray<GOScriptPresetDefinition>;
+}
+
+export interface GOScriptPresetResolution {
+  readonly name: string;
+  readonly sourcePath: string;
+  readonly sourceDisplayPath: string;
+  readonly values: ReadonlyMap<string, GOFlattenedConfigValue>;
+  readonly unknownKeys: ReadonlyArray<string>;
+  readonly allowUnknownKeys: boolean;
+}
+
+export interface GOScriptPresetLoaderOptions {
+  readonly presetName: string;
+  readonly presetFile?: string;
+  readonly paths: GOPaths;
+  readonly schema: GOConfigSchema;
+}
+
+interface ResolvedPresetFile {
+  readonly path: string;
+  readonly displayPath: string;
+}
+
+const DEFAULT_PRESET_FILE_NAMES = ['presets.yaml', 'presets.yml', 'presets.json'] as const;
+const SUPPORTED_PRESET_EXTENSIONS = new Set(['.yaml', '.yml', '.json']);
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const DEFAULT_ALLOW_UNKNOWN_KEYS = true;
+const MAX_SUGGESTION_DISTANCE = 3;
+
+export class GOScriptPresetLoader {
+  loadSelectedPreset(options: GOScriptPresetLoaderOptions): GOScriptPresetResolution {
+    const presetName = this.normalizePresetName(options.presetName);
+    const resolvedFile = this.resolvePresetFile({
+      presetName,
+      ...(options.presetFile !== undefined ? { presetFile: options.presetFile } : {}),
+      paths: options.paths,
+    });
+    const parsed = this.parsePresetFile(resolvedFile.path);
+    const presetFile = this.normalizePresetFile(parsed, resolvedFile.displayPath);
+    const preset = this.selectPreset(presetFile.presets, presetName, resolvedFile.displayPath);
+    const allowUnknownKeys = preset.allowUnknownKeys ?? presetFile.allowUnknownKeys ?? DEFAULT_ALLOW_UNKNOWN_KEYS;
+    const values = GOConfigObjectFlattener.flatten(preset.values);
+    const unknownKeys = this.findUnknownKeys(values, options.schema);
+
+    if (unknownKeys.length > 0 && !allowUnknownKeys) {
+      throw new Error(this.formatUnknownKeysError(presetName, unknownKeys, options.schema));
+    }
+
+    return {
+      name: preset.name,
+      sourcePath: resolvedFile.path,
+      sourceDisplayPath: resolvedFile.displayPath,
+      values,
+      unknownKeys,
+      allowUnknownKeys,
+    };
+  }
+
+  private normalizePresetName(rawName: string): string {
+    const presetName = rawName.trim();
+
+    if (presetName.length === 0) {
+      throw new Error('script.preset.name cannot be empty');
+    }
+
+    if (presetName.includes(',')) {
+      throw new Error(`Multiple script presets are not supported in v1: ${presetName}`);
+    }
+
+    return presetName;
+  }
+
+  private resolvePresetFile(options: {
+    readonly presetName: string;
+    readonly presetFile?: string;
+    readonly paths: GOPaths;
+  }): ResolvedPresetFile {
+    const presetFile = options.presetFile?.trim();
+
+    if (presetFile?.length === 0) {
+      throw new Error('script.preset.file cannot be empty when script.preset.name is configured');
+    }
+
+    if (presetFile !== undefined) {
+      this.validatePresetFileExtension(presetFile);
+      const resolvedPath = this.resolveCustomPresetFile(presetFile, options.paths);
+
+      if (!fs.existsSync(resolvedPath)) {
+        throw new Error(`Preset "${options.presetName}" requested but preset file "${presetFile}" was not found.`);
+      }
+
+      return {
+        path: this.validatePresetFilePath(resolvedPath, presetFile, options.paths),
+        displayPath: presetFile,
+      };
+    }
+
+    for (const fileName of DEFAULT_PRESET_FILE_NAMES) {
+      const result = options.paths.getConfigFilePathWithInfo(fileName);
+      if (result.source !== 'none') {
+        return {
+          path: this.validatePresetFilePath(result.path, fileName, options.paths),
+          displayPath: fileName,
+        };
+      }
+    }
+
+    throw new Error(
+      `Preset "${options.presetName}" requested but presets file was not found.\nChecked: ${DEFAULT_PRESET_FILE_NAMES.join(', ')}`,
+    );
+  }
+
+  private resolveCustomPresetFile(presetFile: string, paths: GOPaths): string {
+    if (path.isAbsolute(presetFile)) {
+      return presetFile;
+    }
+
+    if (this.hasPathSegment(presetFile)) {
+      return path.resolve(process.cwd(), presetFile);
+    }
+
+    return paths.resolvePath(presetFile, GOPathType.CONFIG);
+  }
+
+  private validatePresetFilePath(filePath: string, displayPath: string, paths: GOPaths): string {
+    const realFilePath = fs.realpathSync(filePath);
+    const allowedRoots = this.getAllowedPresetRoots(paths);
+    const isAllowed = allowedRoots.some((root) => this.isPathInsideRoot(realFilePath, root));
+
+    if (!isAllowed) {
+      throw new Error(
+        `Preset file "${displayPath}" must be inside an allowed config directory: ${allowedRoots.join(', ')}`,
+      );
+    }
+
+    return realFilePath;
+  }
+
+  private getAllowedPresetRoots(paths: GOPaths): ReadonlyArray<string> {
+    return [paths.getDataConfigDir(), paths.getLocalConfigsDir()].map((root) => this.realpathOrResolve(root));
+  }
+
+  private realpathOrResolve(rootPath: string): string {
+    return fs.existsSync(rootPath) ? fs.realpathSync(rootPath) : path.resolve(rootPath);
+  }
+
+  private isPathInsideRoot(filePath: string, rootPath: string): boolean {
+    const relativePath = path.relative(rootPath, filePath);
+    return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+  }
+
+  private hasPathSegment(presetFile: string): boolean {
+    return presetFile.startsWith('.') || presetFile.includes('/') || presetFile.includes('\\');
+  }
+
+  private validatePresetFileExtension(filePath: string): void {
+    const extension = path.extname(filePath).toLowerCase();
+    if (!SUPPORTED_PRESET_EXTENSIONS.has(extension)) {
+      throw new Error(
+        `Unsupported presets file extension "${extension || '(none)'}". Supported extensions: .yaml, .yml, .json`,
+      );
+    }
+  }
+
+  private parsePresetFile(filePath: string): unknown {
+    this.validatePresetFileExtension(filePath);
+    const extension = path.extname(filePath).toLowerCase();
+
+    try {
+      if (extension === '.json') {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const normalizedContent = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+        return JSON.parse(normalizedContent) as unknown;
+      }
+
+      return GOYAMLParser.parseFile(filePath);
+    } catch (error: unknown) {
+      throw new Error(`Failed to load presets file ${filePath}: ${getErrorMessage(error)}`, { cause: error });
+    }
+  }
+
+  private normalizePresetFile(parsed: unknown, sourcePath: string): GOScriptPresetFile {
+    if (Array.isArray(parsed)) {
+      return {
+        allowUnknownKeys: DEFAULT_ALLOW_UNKNOWN_KEYS,
+        presets: this.normalizePresetArray(parsed, sourcePath),
+      };
+    }
+
+    if (!this.isRecord(parsed)) {
+      throw new Error(`Invalid presets file ${sourcePath}. Expected a JSON/YAML object or array.`);
+    }
+
+    this.assertNoDangerousKeys(parsed, sourcePath);
+
+    const rawPresets = parsed['presets'];
+    if (rawPresets !== undefined) {
+      const allowUnknownKeys = this.readOptionalBoolean(parsed['allowUnknownKeys'], `${sourcePath}.allowUnknownKeys`);
+      return {
+        ...(allowUnknownKeys !== undefined ? { allowUnknownKeys } : {}),
+        presets: this.normalizePresetArray(rawPresets, sourcePath),
+      };
+    }
+
+    return {
+      allowUnknownKeys: DEFAULT_ALLOW_UNKNOWN_KEYS,
+      presets: this.normalizeTopLevelMap(parsed, sourcePath),
+    };
+  }
+
+  private normalizePresetArray(rawPresets: unknown, sourcePath: string): ReadonlyArray<GOScriptPresetDefinition> {
+    if (!Array.isArray(rawPresets)) {
+      throw new Error(`Invalid presets file ${sourcePath}. Expected "presets" to be an array.`);
+    }
+
+    const presets: GOScriptPresetDefinition[] = [];
+    const names = new Set<string>();
+
+    rawPresets.forEach((entry, index) => {
+      const label = `presets[${String(index)}]`;
+      if (!this.isRecord(entry)) {
+        throw new Error(`Invalid preset definition ${label} in ${sourcePath}. Expected an object.`);
+      }
+
+      this.assertNoDangerousKeys(entry, `${sourcePath}.${label}`);
+
+      const name = this.readRequiredString(entry['name'], `${label}.name`, sourcePath);
+      if (names.has(name)) {
+        throw new Error(`Duplicate preset name "${name}" in ${sourcePath}`);
+      }
+      names.add(name);
+
+      const rawValues = entry['values'];
+      if (!this.isRecord(rawValues)) {
+        throw new Error(`Preset "${name}" in ${sourcePath} must contain an object values field`);
+      }
+
+      const allowUnknownKeys = this.readOptionalBoolean(entry['allowUnknownKeys'], `${label}.allowUnknownKeys`);
+      const description = this.readOptionalString(entry['description'], `${label}.description`);
+
+      presets.push({
+        name,
+        ...(description !== undefined ? { description } : {}),
+        ...(allowUnknownKeys !== undefined ? { allowUnknownKeys } : {}),
+        values: rawValues,
+      });
+    });
+
+    return presets;
+  }
+
+  private normalizeTopLevelMap(
+    data: Record<string, unknown>,
+    sourcePath: string,
+  ): ReadonlyArray<GOScriptPresetDefinition> {
+    const presets: GOScriptPresetDefinition[] = [];
+
+    for (const [name, values] of Object.entries(data)) {
+      this.assertSafeKey(name, sourcePath);
+
+      const normalizedName = name.trim();
+      if (normalizedName.length === 0) {
+        throw new Error(`Invalid preset name in ${sourcePath}. Preset name cannot be empty.`);
+      }
+
+      if (!this.isRecord(values)) {
+        throw new Error(`Preset "${normalizedName}" in ${sourcePath} must be an object`);
+      }
+
+      presets.push({
+        name: normalizedName,
+        values,
+      });
+    }
+
+    return presets;
+  }
+
+  private selectPreset(
+    presets: ReadonlyArray<GOScriptPresetDefinition>,
+    presetName: string,
+    sourcePath: string,
+  ): GOScriptPresetDefinition {
+    const preset = presets.find((candidate) => candidate.name === presetName);
+    if (preset !== undefined) {
+      return preset;
+    }
+
+    const available = presets
+      .map((candidate) => candidate.name)
+      .sort()
+      .join(', ');
+    throw new Error(`Preset "${presetName}" not found in ${sourcePath}. Available presets: ${available || '(none)'}`);
+  }
+
+  private findUnknownKeys(
+    values: ReadonlyMap<string, GOFlattenedConfigValue>,
+    schema: GOConfigSchema,
+  ): ReadonlyArray<string> {
+    const knownKeys = this.buildKnownConfigKeys(schema);
+    return Array.from(values.keys()).filter((key) => !knownKeys.has(key));
+  }
+
+  private buildKnownConfigKeys(schema: GOConfigSchema): Set<string> {
+    const keys = new Set<string>();
+
+    for (const parameter of schema.getAllParameters()) {
+      keys.add(parameter.name);
+      for (const alias of parameter.aliases) {
+        keys.add(alias);
+      }
+    }
+
+    return keys;
+  }
+
+  private formatUnknownKeysError(
+    presetName: string,
+    unknownKeys: ReadonlyArray<string>,
+    schema: GOConfigSchema,
+  ): string {
+    const knownKeys = Array.from(this.buildKnownConfigKeys(schema));
+
+    if (unknownKeys.length === 1) {
+      const key = unknownKeys[0] ?? '';
+      const suggestion = this.findClosestKnownKey(key, knownKeys);
+      return suggestion === undefined
+        ? `Preset "${presetName}" contains unknown key "${key}"`
+        : `Preset "${presetName}" contains unknown key "${key}". Did you mean "${suggestion}"?`;
+    }
+
+    const lines = [`Preset "${presetName}" contains ${String(unknownKeys.length)} unknown key(s):`];
+    for (const key of unknownKeys) {
+      const suggestion = this.findClosestKnownKey(key, knownKeys);
+      lines.push(suggestion === undefined ? `  - ${key}` : `  - ${key} (did you mean "${suggestion}"?)`);
+    }
+    return lines.join('\n');
+  }
+
+  private findClosestKnownKey(unknownKey: string, knownKeys: ReadonlyArray<string>): string | undefined {
+    let bestKey: string | undefined;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (const knownKey of knownKeys) {
+      const distance = damerauLevenshteinDistance(unknownKey, knownKey);
+      if (distance <= MAX_SUGGESTION_DISTANCE && distance < bestDistance) {
+        bestKey = knownKey;
+        bestDistance = distance;
+      }
+    }
+
+    return bestKey;
+  }
+
+  private readRequiredString(value: unknown, label: string, sourcePath: string): string {
+    if (typeof value !== 'string') {
+      throw new Error(`Invalid ${label} in ${sourcePath}. Expected a non-empty string.`);
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new Error(`Invalid ${label} in ${sourcePath}. Expected a non-empty string.`);
+    }
+
+    this.assertSafeKey(trimmed, sourcePath);
+    return trimmed;
+  }
+
+  private readOptionalString(value: unknown, label: string): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (typeof value !== 'string') {
+      throw new Error(`Invalid ${label}. Expected a string.`);
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private readOptionalBoolean(value: unknown, label: string): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (typeof value !== 'boolean') {
+      throw new Error(`Invalid ${label}. Expected a boolean.`);
+    }
+    return value;
+  }
+
+  private assertNoDangerousKeys(data: Record<string, unknown>, location: string): void {
+    for (const [key, value] of Object.entries(data)) {
+      this.assertSafeKey(key, location);
+
+      if (Array.isArray(value)) {
+        value.forEach((item, index) => {
+          if (this.isRecord(item)) {
+            this.assertNoDangerousKeys(item, `${location}.${key}[${String(index)}]`);
+          }
+        });
+        continue;
+      }
+
+      if (this.isRecord(value)) {
+        this.assertNoDangerousKeys(value, `${location}.${key}`);
+      }
+    }
+  }
+
+  private assertSafeKey(key: string, location: string): void {
+    if (DANGEROUS_KEYS.has(key)) {
+      throw new Error(`Unsafe preset key "${location}.${key}" is not allowed`);
+    }
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+}

--- a/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
@@ -9,6 +9,7 @@ import { damerauLevenshteinDistance } from '../config/validation/GOStringDistanc
 import { getErrorMessage } from '../errors/GOErrorUtils.js';
 import { isDangerousKey } from '../security/DangerousKeys.js';
 import { GOPathType, type GOPaths } from '../utils/GOPaths.js';
+import { GOPresetUnknownKeysError } from './GOPresetUnknownKeysError.js';
 
 export interface GOScriptPresetDefinition {
   readonly name: string;
@@ -93,7 +94,12 @@ export class GOScriptPresetLoader {
     const unknownKeys = this.findUnknownKeys(values, knownKeys);
 
     if (unknownKeys.length > 0 && !allowUnknownKeys) {
-      throw new Error(this.formatUnknownKeysError(presetName, unknownKeys, knownKeys));
+      throw new GOPresetUnknownKeysError({
+        presetName,
+        unknownKeys,
+        knownKeys: Array.from(knownKeys),
+        suggestions: this.findUnknownKeySuggestions(unknownKeys, knownKeys),
+      });
     }
 
     return {
@@ -370,27 +376,21 @@ export class GOScriptPresetLoader {
     return keys;
   }
 
-  private formatUnknownKeysError(
-    presetName: string,
+  private findUnknownKeySuggestions(
     unknownKeys: ReadonlyArray<string>,
     knownKeys: ReadonlySet<string>,
-  ): string {
+  ): Readonly<Record<string, string>> {
+    const suggestions = Object.create(null) as Record<string, string>;
     const knownKeyList = Array.from(knownKeys);
 
-    if (unknownKeys.length === 1) {
-      const key = unknownKeys[0] ?? '';
-      const suggestion = this.findClosestKnownKey(key, knownKeyList);
-      return suggestion === undefined
-        ? `Preset "${presetName}" contains unknown key "${key}"`
-        : `Preset "${presetName}" contains unknown key "${key}". Did you mean "${suggestion}"?`;
-    }
-
-    const lines = [`Preset "${presetName}" contains ${String(unknownKeys.length)} unknown key(s):`];
     for (const key of unknownKeys) {
       const suggestion = this.findClosestKnownKey(key, knownKeyList);
-      lines.push(suggestion === undefined ? `  - ${key}` : `  - ${key} (did you mean "${suggestion}"?)`);
+      if (suggestion !== undefined) {
+        suggestions[key] = suggestion;
+      }
     }
-    return lines.join('\n');
+
+    return suggestions;
   }
 
   private findClosestKnownKey(unknownKey: string, knownKeys: ReadonlyArray<string>): string | undefined {
@@ -398,6 +398,10 @@ export class GOScriptPresetLoader {
     let bestDistance = Number.POSITIVE_INFINITY;
 
     for (const knownKey of knownKeys) {
+      if (Math.abs(unknownKey.length - knownKey.length) > MAX_SUGGESTION_DISTANCE) {
+        continue;
+      }
+
       const distance = damerauLevenshteinDistance(unknownKey, knownKey);
       if (distance <= MAX_SUGGESTION_DISTANCE && distance < bestDistance) {
         bestKey = knownKey;

--- a/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptPresetLoader.ts
@@ -275,11 +275,12 @@ export class GOScriptPresetLoader {
 
     rawPresets.forEach((entry, index) => {
       const label = `presets[${String(index)}]`;
+      const sourceLabel = `${sourcePath}.${label}`;
       if (!this.isRecord(entry)) {
         throw new Error(`Invalid preset definition ${label} in ${sourcePath}. Expected an object.`);
       }
 
-      this.assertNoDangerousKeys(entry, `${sourcePath}.${label}`);
+      this.assertNoDangerousKeys(entry, sourceLabel);
 
       const name = this.readRequiredString(entry['name'], `${label}.name`, sourcePath);
       if (names.has(name)) {
@@ -292,8 +293,8 @@ export class GOScriptPresetLoader {
         throw new Error(`Preset "${name}" in ${sourcePath} must contain an object values field`);
       }
 
-      const allowUnknownKeys = this.readOptionalBoolean(entry['allowUnknownKeys'], `${label}.allowUnknownKeys`);
-      const description = this.readOptionalString(entry['description'], `${label}.description`);
+      const allowUnknownKeys = this.readOptionalBoolean(entry['allowUnknownKeys'], `${sourceLabel}.allowUnknownKeys`);
+      const description = this.readOptionalString(entry['description'], `${sourceLabel}.description`);
 
       presets.push({
         name,

--- a/packages/go-common/src/libs/core/script/GOScriptSystemParameters.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptSystemParameters.ts
@@ -30,7 +30,7 @@ export function getGOScriptSystemParameters(): ReadonlyArray<GOConfigParameterOp
       envVar: 'SCRIPT_PRESET_FILE',
       abstract: 'Use a custom script presets file',
       description:
-        'Overrides the default presets.yaml, presets.yml, presets.json lookup. Relative file names are resolved through the script config paths; relative paths with directories are resolved from the current working directory.',
+        'Overrides the default presets.yaml, presets.yml, presets.json lookup. Relative file names are resolved through the script config paths; relative paths with directories are resolved from the current working directory, but the resolved file must be within an allowed config directory such as the data config directory or local configs/.',
       required: false,
       reserved: true,
     },

--- a/packages/go-common/src/libs/core/script/GOScriptSystemParameters.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptSystemParameters.ts
@@ -1,0 +1,38 @@
+import type { GOConfigParameterOptions } from '../config/GOConfigParameter.js';
+import { GOConfigParameterType } from '../config/GOConfigParameterType.js';
+
+export const GOSCRIPT_PRESET_NAME_PARAMETER = 'script.preset.name';
+export const GOSCRIPT_PRESET_FILE_PARAMETER = 'script.preset.file';
+
+export function getGOScriptSystemParameters(): ReadonlyArray<GOConfigParameterOptions> {
+  return [
+    {
+      name: GOSCRIPT_PRESET_NAME_PARAMETER,
+      displayName: 'Script Preset Name',
+      type: GOConfigParameterType.STRING,
+      group: 'GOScript',
+      cliFlag: '--script-preset-name',
+      aliases: ['spn'],
+      envVar: 'SCRIPT_PRESET_NAME',
+      abstract: 'Load values from a named script preset',
+      description:
+        'Selects a preset from presets.yaml, presets.yml, presets.json, or the file configured with script.preset.file. Preset values are lower priority than CLI, config files, environment, and Lambda event values.',
+      required: false,
+      reserved: true,
+    },
+    {
+      name: GOSCRIPT_PRESET_FILE_PARAMETER,
+      displayName: 'Script Preset File',
+      type: GOConfigParameterType.STRING,
+      group: 'GOScript',
+      cliFlag: '--script-preset-file',
+      aliases: ['spf'],
+      envVar: 'SCRIPT_PRESET_FILE',
+      abstract: 'Use a custom script presets file',
+      description:
+        'Overrides the default presets.yaml, presets.yml, presets.json lookup. Relative file names are resolved through the script config paths; relative paths with directories are resolved from the current working directory.',
+      required: false,
+      reserved: true,
+    },
+  ];
+}

--- a/packages/go-common/src/libs/core/script/GOScriptSystemParameters.ts
+++ b/packages/go-common/src/libs/core/script/GOScriptSystemParameters.ts
@@ -4,35 +4,33 @@ import { GOConfigParameterType } from '../config/GOConfigParameterType.js';
 export const GOSCRIPT_PRESET_NAME_PARAMETER = 'script.preset.name';
 export const GOSCRIPT_PRESET_FILE_PARAMETER = 'script.preset.file';
 
-export function getGOScriptSystemParameters(): ReadonlyArray<GOConfigParameterOptions> {
-  return [
-    {
-      name: GOSCRIPT_PRESET_NAME_PARAMETER,
-      displayName: 'Script Preset Name',
-      type: GOConfigParameterType.STRING,
-      group: 'GOScript',
-      cliFlag: '--script-preset-name',
-      aliases: ['spn'],
-      envVar: 'SCRIPT_PRESET_NAME',
-      abstract: 'Load values from a named script preset',
-      description:
-        'Selects a preset from presets.yaml, presets.yml, presets.json, or the file configured with script.preset.file. Preset values are lower priority than CLI, config files, environment, and Lambda event values.',
-      required: false,
-      reserved: true,
-    },
-    {
-      name: GOSCRIPT_PRESET_FILE_PARAMETER,
-      displayName: 'Script Preset File',
-      type: GOConfigParameterType.STRING,
-      group: 'GOScript',
-      cliFlag: '--script-preset-file',
-      aliases: ['spf'],
-      envVar: 'SCRIPT_PRESET_FILE',
-      abstract: 'Use a custom script presets file',
-      description:
-        'Overrides the default presets.yaml, presets.yml, presets.json lookup. Relative file names are resolved through the script config paths; relative paths with directories are resolved from the current working directory, but the resolved file must be within an allowed config directory such as the data config directory or local configs/.',
-      required: false,
-      reserved: true,
-    },
-  ];
-}
+export const GOSCRIPT_SYSTEM_PARAMETERS: ReadonlyArray<GOConfigParameterOptions> = [
+  {
+    name: GOSCRIPT_PRESET_NAME_PARAMETER,
+    displayName: 'Script Preset Name',
+    type: GOConfigParameterType.STRING,
+    group: 'GOScript',
+    cliFlag: '--script-preset-name',
+    aliases: ['spn'],
+    envVar: 'SCRIPT_PRESET_NAME',
+    abstract: 'Load values from a named script preset',
+    description:
+      'Selects a preset from presets.yaml, presets.yml, presets.json, or the file configured with script.preset.file. Preset values are lower priority than CLI, config files, environment, and Lambda event values.',
+    required: false,
+    reserved: true,
+  },
+  {
+    name: GOSCRIPT_PRESET_FILE_PARAMETER,
+    displayName: 'Script Preset File',
+    type: GOConfigParameterType.STRING,
+    group: 'GOScript',
+    cliFlag: '--script-preset-file',
+    aliases: ['spf'],
+    envVar: 'SCRIPT_PRESET_FILE',
+    abstract: 'Use a custom script presets file',
+    description:
+      'Overrides the default presets.yaml, presets.yml, presets.json lookup. Relative file names are resolved through the script config paths; relative paths with directories are resolved from the current working directory, but the resolved file must be within an allowed config directory such as the data config directory or local configs/.',
+    required: false,
+    reserved: true,
+  },
+];

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
@@ -1,0 +1,277 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import type { GOConfigSchema } from '../../config/GOConfigSchema.js';
+import { GOPathEnvironmentVariables } from '../../utils/GOPathEnvironmentVariables.js';
+import { GOPaths } from '../../utils/GOPaths.js';
+import { GOScriptPresetLoader } from '../GOScriptPresetLoader.js';
+
+const managedEnvVars = [GOPathEnvironmentVariables.CONFIG_DIR] as const;
+const originalEnv = new Map<string, string | undefined>(managedEnvVars.map((name) => [name, process.env[name]]));
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const [name, value] of originalEnv.entries()) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createPresetTestContext(): { readonly root: string; readonly configDir: string; readonly paths: GOPaths } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'go-presets-loader-'));
+  tempRoots.push(root);
+  const configDir = path.join(root, 'configs');
+  fs.mkdirSync(configDir, { recursive: true });
+  process.env[GOPathEnvironmentVariables.CONFIG_DIR] = configDir;
+  return {
+    root,
+    configDir,
+    paths: new GOPaths({ scriptName: 'preset-test', baseDir: root }),
+  };
+}
+
+function createSchema(): GOConfigSchema {
+  return {
+    getAllParameters: () => [
+      { name: 'athena.database', aliases: [] },
+      { name: 'athena.workgroup', aliases: [] },
+      { name: 'analysis.rules', aliases: [] },
+      { name: 'output.format', aliases: [] },
+    ],
+  } as unknown as GOConfigSchema;
+}
+
+describe('GOScriptPresetLoader', () => {
+  it('loads wrapper presets from the default presets.yaml file', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      [
+        'version: 1',
+        'allowUnknownKeys: true',
+        'presets:',
+        '  - name: tppmessages',
+        '    values:',
+        '      athena:',
+        '        database: pn_analytics',
+        '        workgroup: primary',
+        '      analysis:',
+        '        rules:',
+        '          - rule-a',
+        '          - rule-b',
+      ].join('\n'),
+    );
+
+    const preset = new GOScriptPresetLoader().loadSelectedPreset({
+      presetName: 'tppmessages',
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.strictEqual(preset.name, 'tppmessages');
+    assert.strictEqual(preset.sourceDisplayPath, 'presets.yaml');
+    assert.strictEqual(preset.sourcePath, fs.realpathSync(path.join(configDir, 'presets.yaml')));
+    assert.strictEqual(preset.allowUnknownKeys, true);
+    assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
+    assert.strictEqual(preset.values.get('athena.workgroup'), 'primary');
+    assert.deepStrictEqual(preset.values.get('analysis.rules'), ['rule-a', 'rule-b']);
+    assert.deepStrictEqual(preset.unknownKeys, []);
+  });
+
+  it('loads top-level map presets from a custom config file', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.prod.yaml'),
+      ['tppmessages:', '  athena.database: pn_analytics', '  output:', '    format: csv'].join('\n'),
+    );
+
+    const preset = new GOScriptPresetLoader().loadSelectedPreset({
+      presetName: 'tppmessages',
+      presetFile: 'presets.prod.yaml',
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
+    assert.strictEqual(preset.values.get('output.format'), 'csv');
+    assert.strictEqual(preset.sourceDisplayPath, 'presets.prod.yaml');
+    assert.strictEqual(preset.allowUnknownKeys, true);
+  });
+
+  it('loads top-level array presets', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      ['- name: tppmessages', '  values:', '    athena:', '      database: pn_analytics'].join('\n'),
+    );
+
+    const preset = new GOScriptPresetLoader().loadSelectedPreset({
+      presetName: 'tppmessages',
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
+  });
+
+  it('loads JSON presets with an UTF-8 BOM', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.json'),
+      '\uFEFF{"presets":[{"name":"tppmessages","values":{"athena":{"database":"pn_analytics"}}}]}',
+    );
+
+    const preset = new GOScriptPresetLoader().loadSelectedPreset({
+      presetName: 'tppmessages',
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
+  });
+
+  it('allows custom preset files only inside config directories', () => {
+    const { configDir, root, paths } = createPresetTestContext();
+    const nestedConfigDir = path.join(configDir, 'nested');
+    fs.mkdirSync(nestedConfigDir, { recursive: true });
+    const allowedFile = path.join(nestedConfigDir, 'presets.prod.yaml');
+    fs.writeFileSync(allowedFile, ['tppmessages:', '  athena.database: pn_analytics'].join('\n'));
+
+    const preset = new GOScriptPresetLoader().loadSelectedPreset({
+      presetName: 'tppmessages',
+      presetFile: allowedFile,
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
+    assert.strictEqual(preset.sourcePath, fs.realpathSync(allowedFile));
+
+    const outsideDir = path.join(root, 'outside');
+    fs.mkdirSync(outsideDir, { recursive: true });
+    const outsideFile = path.join(outsideDir, 'presets.yaml');
+    fs.writeFileSync(outsideFile, ['tppmessages:', '  athena.database: pn_analytics'].join('\n'));
+    const outsideRelativeFile = path.relative(process.cwd(), outsideFile);
+
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'tppmessages',
+          presetFile: outsideFile,
+          paths,
+          schema: createSchema(),
+        }),
+      /must be inside an allowed config directory/,
+    );
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'tppmessages',
+          presetFile: outsideRelativeFile,
+          paths,
+          schema: createSchema(),
+        }),
+      /must be inside an allowed config directory/,
+    );
+  });
+
+  it('reports unknown keys when allowUnknownKeys is true', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(path.join(configDir, 'presets.yaml'), ['tppmessages:', '  athena.databse: typo'].join('\n'));
+
+    const preset = new GOScriptPresetLoader().loadSelectedPreset({
+      presetName: 'tppmessages',
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.deepStrictEqual(preset.unknownKeys, ['athena.databse']);
+  });
+
+  it('throws on unknown keys when allowUnknownKeys is false', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      [
+        'allowUnknownKeys: false',
+        'presets:',
+        '  - name: tppmessages',
+        '    values:',
+        '      athena.databse: typo',
+      ].join('\n'),
+    );
+
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'tppmessages',
+          paths,
+          schema: createSchema(),
+        }),
+      /Preset "tppmessages" contains unknown key "athena\.databse". Did you mean "athena\.database"\?/,
+    );
+  });
+
+  it('throws contextual errors for missing files and missing presets', () => {
+    const { configDir, paths } = createPresetTestContext();
+
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'missing',
+          paths,
+          schema: createSchema(),
+        }),
+      /Preset "missing" requested but presets file was not found/,
+    );
+
+    fs.writeFileSync(path.join(configDir, 'presets.yaml'), ['dev:', '  athena.database: pn_dev'].join('\n'));
+
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'prod',
+          paths,
+          schema: createSchema(),
+        }),
+      /Preset "prod" not found in presets.yaml. Available presets: dev/,
+    );
+  });
+
+  it('throws for empty, multiple, non-object and malformed presets', () => {
+    const { configDir, paths } = createPresetTestContext();
+    const loader = new GOScriptPresetLoader();
+
+    assert.throws(
+      () => loader.loadSelectedPreset({ presetName: ' ', paths, schema: createSchema() }),
+      /script\.preset\.name cannot be empty/,
+    );
+    assert.throws(
+      () => loader.loadSelectedPreset({ presetName: 'base,prod', paths, schema: createSchema() }),
+      /Multiple script presets are not supported in v1: base,prod/,
+    );
+
+    fs.writeFileSync(path.join(configDir, 'presets.yaml'), 'tppmessages: prod\n');
+    assert.throws(
+      () => loader.loadSelectedPreset({ presetName: 'tppmessages', paths, schema: createSchema() }),
+      /Preset "tppmessages" in presets.yaml must be an object/,
+    );
+
+    fs.writeFileSync(path.join(configDir, 'presets.json'), '{bad');
+    fs.rmSync(path.join(configDir, 'presets.yaml'));
+    assert.throws(
+      () => loader.loadSelectedPreset({ presetName: 'tppmessages', paths, schema: createSchema() }),
+      /Failed to load presets file/,
+    );
+  });
+});

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
@@ -124,6 +124,24 @@ describe('GOScriptPresetLoader', () => {
     assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
   });
 
+  it('rejects duplicate normalized preset names in top-level map files', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      ['" tppmessages ":', '  athena.database: first', 'tppmessages:', '  athena.database: second'].join('\n'),
+    );
+
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'tppmessages',
+          paths,
+          schema: createSchema(),
+        }),
+      /Duplicate preset name "tppmessages" in presets\.yaml/,
+    );
+  });
+
   it('loads JSON presets with an UTF-8 BOM', () => {
     const { configDir, paths } = createPresetTestContext();
     fs.writeFileSync(
@@ -137,6 +155,32 @@ describe('GOScriptPresetLoader', () => {
       schema: createSchema(),
     });
 
+    assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
+  });
+
+  it('uses an injected filesystem when reading presets', () => {
+    const { configDir, root, paths } = createPresetTestContext();
+    const presetFile = path.join(configDir, 'virtual.yaml');
+    const readPaths: string[] = [];
+    const loader = new GOScriptPresetLoader({
+      fileSystem: {
+        existsSync: (filePath) => filePath.startsWith(root),
+        realpathSync: (filePath) => filePath,
+        readFileSync: (filePath) => {
+          readPaths.push(filePath);
+          return ['tppmessages:', '  athena.database: pn_analytics'].join('\n');
+        },
+      },
+    });
+
+    const preset = loader.loadSelectedPreset({
+      presetName: 'tppmessages',
+      presetFile,
+      paths,
+      schema: createSchema(),
+    });
+
+    assert.deepStrictEqual(readPaths, [presetFile]);
     assert.strictEqual(preset.values.get('athena.database'), 'pn_analytics');
   });
 

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
@@ -329,6 +329,44 @@ describe('GOScriptPresetLoader', () => {
     );
   });
 
+  it('includes the presets file path in per-preset metadata validation errors', () => {
+    const { configDir, paths } = createPresetTestContext();
+    const loader = new GOScriptPresetLoader();
+
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      [
+        'presets:',
+        '  - name: tppmessages',
+        '    allowUnknownKeys: maybe',
+        '    values:',
+        '      athena.database: pn_analytics',
+      ].join('\n'),
+    );
+
+    assert.throws(
+      () => loader.loadSelectedPreset({ presetName: 'tppmessages', paths, schema: createSchema() }),
+      /Invalid presets\.yaml\.presets\[0\]\.allowUnknownKeys\. Expected a boolean\./,
+    );
+
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      [
+        'presets:',
+        '  - name: tppmessages',
+        '    description:',
+        '      text: invalid',
+        '    values:',
+        '      athena.database: pn_analytics',
+      ].join('\n'),
+    );
+
+    assert.throws(
+      () => loader.loadSelectedPreset({ presetName: 'tppmessages', paths, schema: createSchema() }),
+      /Invalid presets\.yaml\.presets\[0\]\.description\. Expected a string\./,
+    );
+  });
+
   it('throws for empty, multiple, non-object and malformed presets', () => {
     const { configDir, paths } = createPresetTestContext();
     const loader = new GOScriptPresetLoader();

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptPresetLoader.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, it } from 'node:test';
 import type { GOConfigSchema } from '../../config/GOConfigSchema.js';
 import { GOPathEnvironmentVariables } from '../../utils/GOPathEnvironmentVariables.js';
 import { GOPaths } from '../../utils/GOPaths.js';
+import { GOPresetUnknownKeysError } from '../GOPresetUnknownKeysError.js';
 import { GOScriptPresetLoader } from '../GOScriptPresetLoader.js';
 
 const managedEnvVars = [GOPathEnvironmentVariables.CONFIG_DIR] as const;
@@ -263,6 +264,42 @@ describe('GOScriptPresetLoader', () => {
           schema: createSchema(),
         }),
       /Preset "tppmessages" contains unknown key "athena\.databse". Did you mean "athena\.database"\?/,
+    );
+  });
+
+  it('throws a structured error for unknown keys when allowUnknownKeys is false', () => {
+    const { configDir, paths } = createPresetTestContext();
+    fs.writeFileSync(
+      path.join(configDir, 'presets.yaml'),
+      [
+        'allowUnknownKeys: false',
+        'presets:',
+        '  - name: tppmessages',
+        '    values:',
+        '      athena.databse: typo',
+      ].join('\n'),
+    );
+
+    assert.throws(
+      () =>
+        new GOScriptPresetLoader().loadSelectedPreset({
+          presetName: 'tppmessages',
+          paths,
+          schema: createSchema(),
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof GOPresetUnknownKeysError);
+        assert.strictEqual(error.presetName, 'tppmessages');
+        assert.deepStrictEqual(error.unknownKeys, ['athena.databse']);
+        assert.deepStrictEqual([...error.knownKeys].sort(), [
+          'analysis.rules',
+          'athena.database',
+          'athena.workgroup',
+          'output.format',
+        ]);
+        assert.deepStrictEqual({ ...error.suggestions }, { 'athena.databse': 'athena.database' });
+        return true;
+      },
     );
   });
 

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptSystemParameters.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptSystemParameters.test.ts
@@ -25,24 +25,4 @@ describe('GOScriptSystemParameters', () => {
     assert.deepStrictEqual(presetFile.aliases, ['spf']);
     assert.strictEqual(presetFile.envVar, 'SCRIPT_PRESET_FILE');
   });
-
-  it('returns runtime-frozen parameter definitions', () => {
-    const parameters = [...GOSCRIPT_SYSTEM_PARAMETERS];
-    const presetName = parameters.find((parameter) => parameter.name === GOSCRIPT_PRESET_NAME_PARAMETER);
-
-    assert.ok(presetName);
-    assert.strictEqual(Object.isFrozen(parameters), true);
-    assert.strictEqual(Object.isFrozen(presetName), true);
-    assert.strictEqual(Object.isFrozen(presetName.aliases), true);
-
-    assert.throws(() => {
-      parameters.push(presetName);
-    }, TypeError);
-    assert.throws(() => {
-      Object.assign(presetName, { name: '__proto__' });
-    }, TypeError);
-    assert.throws(() => {
-      presetName.aliases?.push('__proto__');
-    }, TypeError);
-  });
 });

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptSystemParameters.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptSystemParameters.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  GOSCRIPT_PRESET_FILE_PARAMETER,
+  GOSCRIPT_PRESET_NAME_PARAMETER,
+  getGOScriptSystemParameters,
+} from '../GOScriptSystemParameters.js';
+
+describe('GOScriptSystemParameters', () => {
+  it('defines reserved preset parameters with stable names, CLI flags, aliases and env vars', () => {
+    const parameters = getGOScriptSystemParameters();
+    const presetName = parameters.find((parameter) => parameter.name === GOSCRIPT_PRESET_NAME_PARAMETER);
+    const presetFile = parameters.find((parameter) => parameter.name === GOSCRIPT_PRESET_FILE_PARAMETER);
+
+    assert.ok(presetName);
+    assert.strictEqual(presetName.reserved, true);
+    assert.strictEqual(presetName.cliFlag, '--script-preset-name');
+    assert.deepStrictEqual(presetName.aliases, ['spn']);
+    assert.strictEqual(presetName.envVar, 'SCRIPT_PRESET_NAME');
+
+    assert.ok(presetFile);
+    assert.strictEqual(presetFile.reserved, true);
+    assert.strictEqual(presetFile.cliFlag, '--script-preset-file');
+    assert.deepStrictEqual(presetFile.aliases, ['spf']);
+    assert.strictEqual(presetFile.envVar, 'SCRIPT_PRESET_FILE');
+  });
+});

--- a/packages/go-common/src/libs/core/script/__tests__/GOScriptSystemParameters.test.ts
+++ b/packages/go-common/src/libs/core/script/__tests__/GOScriptSystemParameters.test.ts
@@ -4,12 +4,12 @@ import { describe, it } from 'node:test';
 import {
   GOSCRIPT_PRESET_FILE_PARAMETER,
   GOSCRIPT_PRESET_NAME_PARAMETER,
-  getGOScriptSystemParameters,
+  GOSCRIPT_SYSTEM_PARAMETERS,
 } from '../GOScriptSystemParameters.js';
 
 describe('GOScriptSystemParameters', () => {
   it('defines reserved preset parameters with stable names, CLI flags, aliases and env vars', () => {
-    const parameters = getGOScriptSystemParameters();
+    const parameters = GOSCRIPT_SYSTEM_PARAMETERS;
     const presetName = parameters.find((parameter) => parameter.name === GOSCRIPT_PRESET_NAME_PARAMETER);
     const presetFile = parameters.find((parameter) => parameter.name === GOSCRIPT_PRESET_FILE_PARAMETER);
 
@@ -24,5 +24,25 @@ describe('GOScriptSystemParameters', () => {
     assert.strictEqual(presetFile.cliFlag, '--script-preset-file');
     assert.deepStrictEqual(presetFile.aliases, ['spf']);
     assert.strictEqual(presetFile.envVar, 'SCRIPT_PRESET_FILE');
+  });
+
+  it('returns runtime-frozen parameter definitions', () => {
+    const parameters = [...GOSCRIPT_SYSTEM_PARAMETERS];
+    const presetName = parameters.find((parameter) => parameter.name === GOSCRIPT_PRESET_NAME_PARAMETER);
+
+    assert.ok(presetName);
+    assert.strictEqual(Object.isFrozen(parameters), true);
+    assert.strictEqual(Object.isFrozen(presetName), true);
+    assert.strictEqual(Object.isFrozen(presetName.aliases), true);
+
+    assert.throws(() => {
+      parameters.push(presetName);
+    }, TypeError);
+    assert.throws(() => {
+      Object.assign(presetName, { name: '__proto__' });
+    }, TypeError);
+    assert.throws(() => {
+      presetName.aliases?.push('__proto__');
+    }, TypeError);
   });
 });

--- a/packages/go-common/src/libs/core/script/index.ts
+++ b/packages/go-common/src/libs/core/script/index.ts
@@ -13,8 +13,10 @@ export type {
   GOScriptPresetLoaderOptions,
   GOScriptPresetResolution,
 } from './GOScriptPresetLoader.js';
+export { GOPresetUnknownKeysError } from './GOPresetUnknownKeysError.js';
+export type { GOPresetUnknownKeysErrorOptions } from './GOPresetUnknownKeysError.js';
 export {
   GOSCRIPT_PRESET_FILE_PARAMETER,
   GOSCRIPT_PRESET_NAME_PARAMETER,
-  getGOScriptSystemParameters,
+  GOSCRIPT_SYSTEM_PARAMETERS,
 } from './GOScriptSystemParameters.js';

--- a/packages/go-common/src/libs/core/script/index.ts
+++ b/packages/go-common/src/libs/core/script/index.ts
@@ -6,3 +6,15 @@ export { GOScript } from './GOScript.js';
 export * from './GOScriptOptions.js';
 export { GOScriptConfigLoader } from './GOScriptConfigLoader.js';
 export type { ConfigLoadResult } from './GOScriptConfigLoader.js';
+export { GOScriptPresetLoader } from './GOScriptPresetLoader.js';
+export type {
+  GOScriptPresetDefinition,
+  GOScriptPresetFile,
+  GOScriptPresetLoaderOptions,
+  GOScriptPresetResolution,
+} from './GOScriptPresetLoader.js';
+export {
+  GOSCRIPT_PRESET_FILE_PARAMETER,
+  GOSCRIPT_PRESET_NAME_PARAMETER,
+  getGOScriptSystemParameters,
+} from './GOScriptSystemParameters.js';

--- a/packages/go-common/src/libs/core/security/DangerousKeys.ts
+++ b/packages/go-common/src/libs/core/security/DangerousKeys.ts
@@ -1,0 +1,11 @@
+const DANGEROUS_KEY_VALUES = ['__proto__', 'constructor', 'prototype'] as const;
+
+const DANGEROUS_KEYS = new Set<string>(DANGEROUS_KEY_VALUES);
+
+export function isDangerousKey(key: string): boolean {
+  return DANGEROUS_KEYS.has(key);
+}
+
+export function formatUnsafeKeyLocation(location: string, key: string): string {
+  return location.length > 0 ? `${location}.${key}` : key;
+}


### PR DESCRIPTION
## Description

Introduce GOPresetConfigProvider to manage script presets, along with GOScriptPresetLoader for loading presets from YAML and JSON files. Enhance GOScript to support preset loading and update GOScriptConfigLoader to prepare providers before loading configurations. Add tests to ensure functionality.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
