### PR TITLE
feat(go-ai): switch to on-demand Mistral model to avoid cross-region …

### DIFF
--- a/functions/go-AILambda/esbuild.config.mjs
+++ b/functions/go-AILambda/esbuild.config.mjs
@@ -30,7 +30,7 @@ await esbuild.build({
   external:    ['@aws-sdk/*'],
   // yaml must be bundled — not available in Lambda runtime
   banner: {
-    js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+    js: "import { createRequire as __banner_createRequire } from 'module'; const require = __banner_createRequire(import.meta.url);",
   },
 });
 

--- a/packages/go-ai/src/GOBedrockClient.ts
+++ b/packages/go-ai/src/GOBedrockClient.ts
@@ -16,7 +16,7 @@ import type { GOAIRequest, GOAIResponse } from './types/index.js';
 import { GOAIHat } from './types/index.js';
 import { getTemplate } from './prompts/index.js';
 
-const DEFAULT_MODEL_ARN = 'arn:aws:bedrock:eu-south-1:170533023216:inference-profile/eu.amazon.nova-pro-v1:0';
+const DEFAULT_MODEL_ID = 'mistral.ministral-3-14b-instruct';
 
 export interface GOBedrockClientOptions {
   readonly region?: string;
@@ -34,9 +34,9 @@ export class GOBedrockClient {
   private readonly modelArn: string;
 
   constructor(options: GOBedrockClientOptions = {}) {
-    const region = options.region ?? process.env['AWS_REGION'] ?? 'eu-south-1';
+    const region = options.region ?? process.env['BEDROCK_REGION'] ?? process.env['AWS_REGION'] ?? 'eu-south-1';
     const profile = options.profile ?? process.env['AWS_PROFILE'];
-    this.modelArn = options.modelArn ?? process.env['BEDROCK_MODEL_ARN'] ?? DEFAULT_MODEL_ARN;
+    this.modelArn = options.modelArn ?? process.env['BEDROCK_MODEL_ARN'] ?? DEFAULT_MODEL_ID;
 
     this.client = new BedrockRuntimeClient({
       region,


### PR DESCRIPTION
…inference routing blocked by organization policy

## Description

Il modello precedente (Nova Pro) utilizzava un inference profile cross-region (eu.amazon.nova-pro-v1:0) che distribuisce le richieste su più region EU. Una policy organizzativa (SCP) blocca bedrock:InvokeModel su eu-north-1, causando errori intermittenti quando il profilo ruotava su quella region.

Questa modifica sostituisce il modello di default con Mistral Ministral 3 14B, disponibile on-demand in eu-south-1 senza routing cross-region e  aggiunge il supporto alla variabile d'ambiente BEDROCK_REGION per disaccoppiare la region Bedrock da AWS_REGION (riservata in Lambda).
BTW: rinomina l'alias createRequire nel banner esbuild per evitare un conflitto di dichiarazione duplicata nel runtime ESM di Lambda.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings (`pnpm lint`)
- [ ] The build passes (`pnpm build`)
- [ ] Type checking passes (`pnpm type-check`)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
